### PR TITLE
Add gpu and docs extras to tox setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,5 +83,7 @@ passenv =
     GITHUB_ACTIONS
 extras =
     testing
+    gpu
+    docs
 commands = python -m pytest -vv --color=yes --cov=snputils --cov-report=xml
 """


### PR DESCRIPTION
This makes it possible to reuse the cached pip packages in the CI/CD action, thus reducing its execution time. It will also be useful in the future when we add unit tests for GPU-powered functions