### PR TITLE
mdPCA: Convert indID from labels DataFrame to string

### DIFF
--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -561,6 +561,7 @@ def add_AB_indIDs(ind_IDs):
 
 def process_labels_weights(labels_file, masks, rs_ID_list, ind_ID_list, average_strands, ancestry, min_percent_snps, remove_labels_dict, is_weighted, save_masks, masks_file, num_arrays=1):
     labels_df = pd.read_csv(labels_file, sep='\t')
+    labels_df['indID'] = labels_df['indID'].astype(str)
     label_list = []
     weight_list = []
     for array_ind in range(num_arrays):


### PR DESCRIPTION
## Concept

A bug was identified in mdPCA when processing the labels file, leading to the error below:

```
ValueError: Found array with 0 sample(s) (shape=(0, 0)) while a minimum of 1 is required by TruncatedSVD.
```

## Issue Description

The error occurs because the `indID` column in the labels file might contain integer values (e.g., `403`). However, the identifiers in `laiobj` are stored as strings. When filtering with:

```python
labels = np.array(labels_df['label'][labels_df['indID'].isin(temp_ind_IDs)])
```

the mismatch between integer and string types means that no samples match, resulting in an empty array.

## Resolution

To fix this, we ensure that the `indID` values in the labels file are treated as strings. We convert the indID column immediately after loading the file:

```python
labels_df['indID'] = labels_df['indID'].astype(str)
```