### PR TITLE
Improve mdPCA and maasMDS

### DIFF
--- a/demos/mdPCA_maasMDS.ipynb
+++ b/demos/mdPCA_maasMDS.ipynb
@@ -109,7 +109,7 @@
     "* **ancestry**: Ancestry for which dimensionality reduction is to be performed. Ancestry counter starts at `0`. The ancestry input can be:\n",
     "    * An integer (e.g., 0, 1, 2, 3, 4).\n",
     "    * A string representation of an integer (e.g., '0', '1', '2', '3', '4').\n",
-    "    * A string matching one of the ancestry map values (e.g., 'Africa', 'Americas', ''Europe, 'SouthAsia', 'EastAsia').\n",
+    "    * A string matching one of the ancestry map values (e.g., 'Africa', 'Americas', 'Europe', 'SouthAsia', 'EastAsia').\n",
     "* **average_strands**: True if the haplotypes from the two parents are to be combined (averaged) for each individual, or False otherwise.\n",
     "* **force_nan_incomplete_strands**: If True, sets the result to NaN if either haplotype in a pair is NaN. Otherwise, computes the mean while ignoring NaNs (e.g., 0|NaN -> 0, 1|NaN -> 1).\n",
     "* **is_weighted**: If True, assigns individual weights from the `weight` column in `labels_file`. Otherwise, all individuals have equal weight of `1`.\n",

--- a/demos/mdPCA_maasMDS.ipynb
+++ b/demos/mdPCA_maasMDS.ipynb
@@ -31,16 +31,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1. Load Input Data for mdPCA\n",
+    "### 1. Load Input Data\n",
     "\n",
-    "Load data files required for running mdPCA, including SNP and LAI data, along with the labels file specifying ancestry labels."
+    "Load data files required for running mdPCA and maasMDS, including SNP and LAI data, along with the labels file specifying ancestry labels.\n",
+    "* **SNP data** is loaded from a VCF file into a `SNPObject`. The parameter sum_strands=False ensures that haplotypes are not combined initially.\n",
+    "* **LAI data** is loaded from an MSP file into a `LocalAncestryObject`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 73,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[INFO] 2025-03-05 14:48:27: Reading ../data/easComp_6_samples_chr1.vcf\n",
+      "[INFO] 2025-03-05 14:48:28: Finished reading ../data/easComp_6_samples_chr1.vcf\n",
+      "[INFO] 2025-03-05 14:48:28: Reading '../data/easComp_6_samples_chr1.msp'...\n",
+      "\n",
+      "Ancestry map: {'0': 'Africa', '1': 'Americas', '2': 'Europe', '3': 'SouthAsia', '4': 'EastAsia'}\n"
+     ]
+    }
+   ],
    "source": [
     "# File paths for SNP data, LAI data, and sample labels\n",
     "vcf_path = '../data/easComp_6_samples_chr1.vcf'\n",
@@ -53,6 +67,9 @@
     "# Load LAI data from MSP file\n",
     "laiobj = MSPReader(msp_path).read()\n",
     "\n",
+    "# Display the ancestry mapping\n",
+    "print(\"\\nAncestry map:\", laiobj.ancestry_map)\n",
+    "\n",
     "# Configure logging to display messages in the console\n",
     "logging.config.dictConfig(logger_config(verbose=True))"
    ]
@@ -61,92 +78,130 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2. Run mdPCA\n",
+    "### 2. Understanding the Labels File\n",
     "\n",
-    "Initialize and run the mdPCA analysis."
+    "The labels file is a TSV text file that contains essential metadata about each individual in your study. mdPCA and maasMDS use this file to align the genotype data (from snpobj) and local ancestry data (from laiobj) with population information. Below are key columns and how they are used:\n",
+    "\n",
+    "* `indID`: Unique identifier for each individual; must match identifiers in `snpobj` and `laiobj`.\n",
+    "* `label`: Population or group label (e.g., \"popA\", \"popB\"). These labels help interpret how samples cluster on principal components (e.g., color-coding in PCA plots).\n",
+    "* `weight`: Numeric weight assigned to each individual. If an individual’s weight is 0, that individual is excluded from the analysis. If `is_weighted=False`, this column is ignored.\n",
+    "* `combination`: Assigns individuals into combined groups. This is especially useful when `group_snp_frequencies_only=True`: \n",
+    "    * A combination value of 0 means no grouping; each individual is considered separately.\n",
+    "    * A non-zero value (e.g., 1, 2, 3) indicates that all individuals with the same combination number are grouped together.\n",
+    "* `combination_weight`: Weight assigned to each group if combination is non-zero. If not provided, defaults to 1.\n",
+    "\n",
+    "All members of a group must share the same `label` and `combination_weight`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Run mdPCA\n",
+    "\n",
+    "Initialize and run the mdPCA analysis.\n",
+    "\n",
+    "**Key Parameter Explanations**\n",
+    "\n",
+    "* **snpobj**: SNPObject with SNP data loaded from the VCF file.\n",
+    "* **laiobj**: LocalAncestryObject with LAI data loaded from the MSP file.\n",
+    "* **labels_file**: Sample labels file, mapping individuals to population labels and optionally groups.\n",
+    "* **ancestry**: Ancestry for which dimensionality reduction is to be performed. Ancestry counter starts at `0`. The ancestry input can be:\n",
+    "    * An integer (e.g., 0, 1, 2, 3, 4).\n",
+    "    * A string representation of an integer (e.g., '0', '1', '2', '3', '4').\n",
+    "    * A string matching one of the ancestry map values (e.g., 'Africa', 'Americas', ''Europe, 'SouthAsia', 'EastAsia').\n",
+    "* **average_strands**: True if the haplotypes from the two parents are to be combined (averaged) for each individual, or False otherwise.\n",
+    "* **force_nan_incomplete_strands**: If True, sets the result to NaN if either haplotype in a pair is NaN. Otherwise, computes the mean while ignoring NaNs (e.g., 0|NaN -> 0, 1|NaN -> 1).\n",
+    "* **is_weighted**: If True, assigns individual weights from the `weight` column in `labels_file`. Otherwise, all individuals have equal weight of `1`.\n",
+    "* **min_percent_snps**: Minimum percentage of SNPs that must be known for an individual and of the ancesstry of interet to be included in the analysis. All individuals with fewer percent of unmasked SNPs than this threshold will be excluded.\n",
+    "* **group_snp_frequencies_only**: If True, mdPCA is performed exclusively on group-level SNP frequencies, ignoring individual-level data. This applies when `is_weighted` is set to True and a `combination` column is provided in the `labels_file`,  meaning individuals are aggregated into groups based on their assigned labels. If False, mdPCA is performed on individual-level SNP data alone or on both individual-level and group-level SNP frequencies when `is_weighted` is True and a `combination` column is provided.\n",
+    "* **n_components**: The number of principal components."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[INFO] 2025-01-03 05:18:59: ------ Array 1 Processing: ------\n",
-      "[INFO] 2025-01-03 05:18:59: VCF Processing Time: --- 0.09156608581542969 seconds ---\n",
-      "[INFO] 2025-01-03 05:18:59: TSV Processing Time: --- 0.08198070526123047 seconds ---\n",
-      "[INFO] 2025-01-03 05:18:59: Masking for ancestry 0 --- 0.0006837844848632812 seconds ---\n",
-      "[INFO] 2025-01-03 05:18:59: Masking for ancestry 1 --- 0.0010597705841064453 seconds ---\n",
-      "[INFO] 2025-01-03 05:18:59: Masking for ancestry 2 --- 0.0010416507720947266 seconds ---\n",
-      "[INFO] 2025-01-03 05:18:59: Masking for ancestry 3 --- 0.002353668212890625 seconds ---\n",
-      "[INFO] 2025-01-03 05:18:59: Masking for ancestry 4 --- 0.0014388561248779297 seconds ---\n",
-      "[INFO] 2025-01-03 05:18:59: Covariance Matrix --- 0.1636357307434082 seconds ---\n",
-      "[INFO] 2025-01-03 05:18:59: Percent variance explained by the principal component 1: 40.669909765458044\n",
-      "[INFO] 2025-01-03 05:18:59: Percent variance explained by the principal component 2: 35.32331274768433\n"
+      "[INFO] 2025-03-05 14:46:57: ------ Array Processing: ------\n",
+      "[INFO] 2025-03-05 14:46:57: SNPObject Processing Time: --- 0.13059544563293457 seconds ---\n",
+      "[DEBUG] 2025-03-05 14:46:57: Number of SNPs within window ranges for chromosome 1: 64073\n",
+      "[INFO] 2025-03-05 14:46:57: TSV Processing Time: --- 0.016486406326293945 seconds ---\n",
+      "[INFO] 2025-03-05 14:46:57: Masking for ancestry 4 --- 0.0012 seconds\n",
+      "[INFO] 2025-03-05 14:46:57: Covariance Matrix --- 0.16022467613220215 seconds ---\n",
+      "[INFO] 2025-03-05 14:46:57: Percent variance explained by the principal component 1: 40.669909765458044\n",
+      "[INFO] 2025-03-05 14:46:57: Percent variance explained by the principal component 2: 35.323312747684334\n"
      ]
     }
    ],
    "source": [
     "# Initialize the mdPCA object with SNP and LAI data, labels file, and selected ancestry\n",
     "mdpca = mdPCA(\n",
-    "    snpobj=snpobj,            # SNP data object\n",
-    "    laiobj=laiobj,            # LAI data object\n",
-    "    labels_file=labels_file,  # File containing sample labels\n",
-    "    ancestry=\"4\",             # Ancestry component to analyze (e.g., '4' for East Asia)\n",
-    "    average_strands=False     # Diploid data\n",
+    "    method='weighted_cov_pca',         # Weighted covariance PCA (default)\n",
+    "    snpobj=snpobj,                     # SNP genotype data from VCF\n",
+    "    laiobj=laiobj,                     # Local ancestry data from MSP\n",
+    "    labels_file=labels_file,           # Sample metadata file (.tsv) with population labels and optional weights\n",
+    "    ancestry='EastAsia',               # Ancestry of interest (string or integer index)\n",
+    "    average_strands=False,             # Keep haplotypes separate instead of averaging parental strands\n",
+    "    force_nan_incomplete_strands=False,# If True, averaged strands with one missing haplotype are set to NaN\n",
+    "    is_weighted=False,                 # If True, applies weights from the 'weight' column in labels_file\n",
+    "    min_percent_snps=4,                # Minimum SNP coverage threshold from ancestry of interest for individual inclusion\n",
+    "    group_snp_frequencies_only=False,  # If True, analyzes only group-level SNP frequencies (excludes individual sequences)\n",
+    "    n_components=2                     # Number of principal components to compute\n",
     ")"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now inspect the output attributes:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "X_new [[ 0.05753786 -0.07705574]\n",
+      "X_new_ shape: [[ 0.05753786 -0.07705574]\n",
       " [ 0.31123924  0.07635565]\n",
       " [-0.14243854 -0.03442202]\n",
       " [-0.07117519 -0.22365777]\n",
-      " [-0.15516337  0.25877988]]\n"
+      " [-0.15516337  0.25877988]]\n",
+      "\n",
+      "haplotypes: ['GA000856_GA000856_A', 'GA000856_GA000856_B', 'GA000857_GA000857_A', 'GA000858_GA000858_A', 'GA000858_GA000858_B']\n",
+      "samples_: ['GA000856_GA000856', 'GA000856_GA000856', 'GA000857_GA000857', 'GA000858_GA000858', 'GA000858_GA000858']\n",
+      "Total variants: 64073\n",
+      "variants_id_ (first few): [1.435428, 1.678428, 1.555838, 1.566838, 1.564648]\n"
      ]
     }
    ],
    "source": [
-    "print(\"X_new\", mdpca.X_new_)"
+    "print(\"X_new_ shape:\", mdpca.X_new_)\n",
+    "print(\"\\nhaplotypes:\", mdpca.haplotypes_)\n",
+    "print(\"samples_:\", mdpca.samples_ if hasattr(mdpca, \"samples_\") else \"Not available\")\n",
+    "print(\"Total variants:\", len(mdpca.variants_id_))\n",
+    "print(\"variants_id_ (first few):\", mdpca.variants_id_[:5])"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 5,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "samples ['GA000856_GA000856', 'GA000856_GA000856', 'GA000857_GA000857', 'GA000858_GA000858', 'GA000858_GA000858']\n",
-      "haplotypes ['GA000856_GA000856_A', 'GA000856_GA000856_B', 'GA000857_GA000857_A', 'GA000858_GA000858_A', 'GA000858_GA000858_B']\n",
-      "n_samples 3\n",
-      "n_haplotypes 5\n"
-     ]
-    }
-   ],
    "source": [
-    "print(\"samples\", mdpca.samples_)\n",
-    "print(\"haplotypes\", mdpca.haplotypes_)\n",
-    "print(\"n_samples\", mdpca.n_samples)\n",
-    "print(\"n_haplotypes\", mdpca.n_haplotypes)"
+    "And plot the PCA results:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
@@ -175,28 +230,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[INFO] 2025-01-03 05:19:06: ------ Array 1 Processing: ------\n",
-      "[INFO] 2025-01-03 05:19:06: VCF Processing Time: --- 0.16530919075012207 seconds ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[INFO] 2025-01-03 05:19:06: TSV Processing Time: --- 0.12661957740783691 seconds ---\n",
-      "[INFO] 2025-01-03 05:19:06: Masking for ancestry 0 --- 0.0012772083282470703 seconds ---\n",
-      "[INFO] 2025-01-03 05:19:06: Masking for ancestry 1 --- 0.0015435218811035156 seconds ---\n",
-      "[INFO] 2025-01-03 05:19:06: Masking for ancestry 2 --- 0.0015606880187988281 seconds ---\n",
-      "[INFO] 2025-01-03 05:19:06: Masking for ancestry 3 --- 0.003694772720336914 seconds ---\n",
-      "[INFO] 2025-01-03 05:19:06: Masking for ancestry 4 --- 0.002327442169189453 seconds ---\n",
-      "[INFO] 2025-01-03 05:19:06: Distance Matrix building: --- 0.006646871566772461 seconds ---\n"
+      "[INFO] 2025-03-05 14:47:50: ------ Array Processing: ------\n",
+      "[INFO] 2025-03-05 14:47:50: SNPObject Processing Time: --- 0.13159394264221191 seconds ---\n",
+      "[DEBUG] 2025-03-05 14:47:50: Number of SNPs within window ranges for chromosome 1: 64073\n",
+      "[INFO] 2025-03-05 14:47:50: TSV Processing Time: --- 0.014508962631225586 seconds ---\n",
+      "[INFO] 2025-03-05 14:47:50: Masking for ancestry 4 --- 0.0014 seconds\n",
+      "[INFO] 2025-03-05 14:47:50: Distance Matrix building: --- 0.008743047714233398 seconds ---\n"
      ]
     }
    ],
@@ -205,62 +251,67 @@
     "logging.config.dictConfig(logger_config(verbose=True))\n",
     "\n",
     "# Initialize the maasMDS object with SNP and LAI data, labels file, and selected ancestry\n",
-    "mds = maasMDS(\n",
-    "    snpobj=snpobj,           # SNP data object\n",
-    "    laiobj=laiobj,           # LAI data object\n",
-    "    labels_file=labels_file, # File containing sample labels\n",
-    "    ancestry=\"4\",            # Ancestry component to analyze (e.g., '4' for East Asia)\n",
-    "    average_strands=False    # Diploid data\n",
+    "maasmds = maasMDS(\n",
+    "    snpobj=snpobj,                     # SNP genotype data from VCF\n",
+    "    laiobj=laiobj,                     # Local ancestry data from MSP\n",
+    "    labels_file=labels_file,           # Sample metadata file (.tsv) with population labels and optional weights\n",
+    "    ancestry='EastAsia',               # Ancestry of interest (string or integer index)\n",
+    "    average_strands=False,             # Keep haplotypes separate instead of averaging parental strands\n",
+    "    force_nan_incomplete_strands=False,# If True, averaged strands with one missing haplotype are set to NaN\n",
+    "    is_weighted=False,                 # If True, applies weights from the 'weight' column in labels_file\n",
+    "    min_percent_snps=4,                # Minimum SNP coverage threshold from ancestry of interest for individual inclusion\n",
+    "    group_snp_frequencies_only=False,  # If True, analyzes only group-level SNP frequencies (excludes individual sequences)\n",
+    "    n_components=2                     # Number of principal components to compute\n",
     ")"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now inspect the output attributes:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "X_new [[-0.4475931  -0.02684126]\n",
+      "X_new_ shape: [[-0.4475931  -0.02684126]\n",
       " [-0.53592473  0.33056938]\n",
       " [-0.00128624 -0.34214979]\n",
       " [ 0.37509062 -0.60215815]\n",
-      " [ 0.60971344  0.64057983]]\n"
+      " [ 0.60971344  0.64057983]]\n",
+      "\n",
+      "haplotypes: ['GA000856_GA000856_A', 'GA000856_GA000856_B', 'GA000857_GA000857_A', 'GA000858_GA000858_A', 'GA000858_GA000858_B']\n",
+      "samples_: ['GA000856_GA000856', 'GA000856_GA000856', 'GA000857_GA000857', 'GA000858_GA000858', 'GA000858_GA000858']\n",
+      "Total variants: 64073\n",
+      "variants_id_ (first few): [1.435428, 1.678428, 1.555838, 1.566838, 1.564648]\n"
      ]
     }
    ],
    "source": [
-    "print(\"X_new\", mds.X_new_)"
+    "print(\"X_new_ shape:\", maasmds.X_new_)\n",
+    "print(\"\\nhaplotypes:\", maasmds.haplotypes_)\n",
+    "print(\"samples_:\", maasmds.samples_ if hasattr(maasmds, \"samples_\") else \"Not available\")\n",
+    "print(\"Total variants:\", len(maasmds.variants_id_))\n",
+    "print(\"variants_id_ (first few):\", maasmds.variants_id_[:5])"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 10,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "samples ['GA000856_GA000856', 'GA000856_GA000856', 'GA000857_GA000857', 'GA000858_GA000858', 'GA000858_GA000858']\n",
-      "haplotypes ['GA000856_GA000856_A', 'GA000856_GA000856_B', 'GA000857_GA000857_A', 'GA000858_GA000858_A', 'GA000858_GA000858_B']\n",
-      "n_samples 3\n",
-      "n_haplotypes 5\n"
-     ]
-    }
-   ],
    "source": [
-    "print(\"samples\", mdpca.samples_)\n",
-    "print(\"haplotypes\", mdpca.haplotypes_)\n",
-    "print(\"n_samples\", mdpca.n_samples)\n",
-    "print(\"n_haplotypes\", mdpca.n_haplotypes)"
+    "And plot the PCA results:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -275,15 +326,8 @@
     }
    ],
    "source": [
-    "scatter(mds, labels_file)"
+    "scatter(maasmds, labels_file)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -324,31 +324,43 @@ def process_beagle(beagle_file, rs_ID_dict, rsid_or_chrompos):
 
 def process_vcf(snpobj, rs_ID_dict, rsid_or_chrompos):
     """                                                                                       
-    VCF File Processing                                                 
-                                                                                               
-    Parameters                                                                                
-    ----------                                                                                
-    snpobj    : string with the path of our vcf file. 
-    rs_ID_dict  : dictionary showing the previous encoding for a specific 
-                  rs ID.
+    Process a VCF file to extract genotype and variant information.
 
-    Returns                                                                                   
-    -------   
-    calldata_gt.  : (m, n) array
-                  Genetic matrix indicating the encoding for individual n at 
-                  poisition m. 
-    ind_IDs     : (n,) array
-                  Individual IDs for all individuals in the matrix. 
-    variants_id      : (m,) array
-                  rs IDs of all the positions included in our matrix. 
-    positions   :  
-    rs_ID_dict  : dictionary showing the previous encoding for a specific 
-                  rs ID.
+    This function processes a VCF file to extract genotypic data, reformat variant identifiers, 
+    and encode genetic information into a structured genotype matrix.
+
+    Args:
+        snpobj (dict): 
+            A SNPObject instance.
+        rs_ID_dict (dict): 
+            A dictionary mapping rsIDs or variant positions to their reference alleles.
+            If an rsID is not found in the dictionary, it will be added.
+        rsid_or_chrompos (int): 
+            Format specification for variant identifiers:
+            - `1`: Use rsID format.
+            - `2`: Use Chromosome_Position format.
+
+    Returns:
+        Tuple:
+            - np.ndarray of shape (n_snps, n_samples * ploidy): 
+                A genotype matrix where `n_snps` represents the number of genomic 
+                positions and `n_samples * ploidy` represents the flattened genotype calls 
+                for diploid individuals.
+            - np.ndarray of shape (n_samples * ploidy,): 
+                Array of individual IDs corresponding to the genotype matrix.
+            - list of int or float: 
+                List of variant identifiers, formatted based on `rsid_or_chrompos` selection.
+            - list of int: 
+                List of genomic positions corresponding to the variants.
+            - dict: 
+                Updated reference allele dictionary mapping variant identifiers to reference alleles.
     """
     start_time = time.time()
-    gt = snpobj['calldata_gt']
-    n_variants, n_samples, ploidy = gt.shape
-    calldata_gt = gt.reshape(n_variants, n_samples * ploidy).astype(np.float16)
+
+    # Extract genotype data and reshape to 2D (n_snps, n_samples * ploidy)
+    calldata_gt = snpobj['calldata_gt']
+    n_snps, n_samples, ploidy = calldata_gt.shape
+    calldata_gt = calldata_gt.reshape(n_snps, n_samples * ploidy).astype(np.float16)
     np.place(calldata_gt, calldata_gt < 0, np.nan)
     if rsid_or_chrompos == 1:
         IDs = snpobj['variants_id']

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -234,7 +234,6 @@ def process_tsv_msp(laiobj, variants_pos, variants_chrom, calldata_gt, variants_
     next_pos_tsv = tsv_spos[i_tsv+1]
     next_chrom_tsv = tsv_chromosomes[i_tsv+1]
 
-    assign_dict = {}
     for i, pos in enumerate(variants_pos):
         if pos >= next_pos_tsv and int(variants_chrom[i]) == int(next_chrom_tsv) and i_tsv + 1 < tsv_matrix.shape[0]:
             i_tsv += 1

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -503,7 +503,6 @@ def mask(ancestry_matrix, calldata_gt, unique_ancestries, ancestry_int_list, ave
 def get_masked_matrix(
         snpobj, 
         laiobj, 
-        vit_or_fbk_or_fbtsv_or_msptsv,
         is_masked, 
         num_ancestries, 
         average_strands, 
@@ -521,8 +520,6 @@ def get_masked_matrix(
             A SNPObject instance.
         laiobj: 
             Local ancestry inference object, used for ancestry-based masking.
-        vit_or_fbk_or_fbtsv_or_msptsv (int): 
-            Indicator for ancestry file type (1 = vit, 2 = fbk, 3 = fbtsv, 4 = msptsv).
         is_masked (bool): 
             Whether ancestry-based masking should be applied.
         num_ancestries (int): 
@@ -608,8 +605,6 @@ def array_process(snpobj, laiobj, average_strands, is_masked, rsid_or_chrompos, 
                  List of individual IDs for each of the processed arrays.
 
     """
-    vit_or_fbk_or_fbtsv_or_msptsv_list = [4]
-
     # Initialization:
     rs_ID_dict = {}
     masks =[]
@@ -623,7 +618,7 @@ def array_process(snpobj, laiobj, average_strands, is_masked, rsid_or_chrompos, 
         logging.info("------ Array "+ str(i+1) + " Processing: ------")
         genome_matrix, ind_IDs, variants_id, rs_ID_dict = get_masked_matrix(snpobj, 
                                                                        laiobj,
-                                                                       vit_or_fbk_or_fbtsv_or_msptsv_list[i], is_masked,
+                                                                       is_masked,
                                                                        num_ancestries, average_strands, rs_ID_dict,
                                                                        rsid_or_chrompos)
 

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -491,7 +491,6 @@ def get_masked_matrix(
         snpobj, 
         laiobj, 
         is_masked, 
-        n_ancestries, 
         average_strands, 
         rsid_or_chrompos
     ):
@@ -504,8 +503,6 @@ def get_masked_matrix(
         is_masked (bool): 
             If `True`, applies ancestry-specific masking to the genotype matrix, retaining only genotype data 
             corresponding to the specified `ancestry`. If `False`, uses the full, unmasked genotype matrix.
-        n_ancestries (int): 
-            Number of unique ancestry groups in the dataset.
         average_strands (bool): 
             Whether to average haplotypes for each individual.
         rsid_or_chrompos (int): 
@@ -527,6 +524,9 @@ def get_masked_matrix(
     # format variant identifiers, and ensure consistency in allele encoding
     calldata_gt, ind_IDs, variants_id, positions = process_snpobj(snpobj, rsid_or_chrompos)
     
+    # Obtain number of unique ancestries in LocalAncestryObject
+    n_ancestries = laiobj.n_ancestries
+
     if is_masked:
         # Obtain a 
         # Process the LocalAncestryObject containing ancestry segment data
@@ -557,7 +557,7 @@ def get_masked_matrix(
 
 def array_process(snpobj, laiobj, average_strands, is_masked, rsid_or_chrompos): 
     """                                                                                       
-    Obtain ancestry-based masked genotype matrixes, SNP identifiers, and haplotype identifiers.
+    Obtain ancestry-based masked genotype matrixes and correponding SNP identifiers and haplotype identifiers.
 
     Args:
         snpobj (SNPObject): 
@@ -579,27 +579,26 @@ def array_process(snpobj, laiobj, average_strands, is_masked, rsid_or_chrompos):
             - masks (np.ndarray): 
                 If `is_masked` is True, returns a dictionary containing masked genotype matrices for each 
                 ancestry group. If False, returns the unmasked genotype matrix.
-            - variants_id (list of list): 
-                A list where each entry contains the SNP identifiers (rs IDs) for a given array.
-            - haplotypes (list of np.ndarray): 
-                A list where each entry contains individual IDs for the corresponding array.
+            - variants_id (list of str): 
+                Unique identifiers (IDs) for each SNP, potentially reduced if there are SNPs not present in the `laiboj`.
+                The format will depend on `rsid_or_chrompos`.
+            - haplotypes (list of str): 
+                Unique sample identifiers in the masked arrays.
     """
-    # Obtain number of unique ancestries in LocalAncestryObject
-    n_ancestries = laiobj.n_ancestries
-
+    # Obtain the masked genotype matrices, SNP identifiers, and haplotype identifiers
     logging.info("------ Array Processing: ------")
     masks, haplotypes, variants_id = get_masked_matrix(
         snpobj, 
         laiobj,
         is_masked,
-        n_ancestries, 
         average_strands, 
         rsid_or_chrompos
     )
 
     if average_strands:
+        # Remove duplicate haplotype identifiers (A/B labels)
         haplotypes = remove_AB_indIDs(haplotypes)
-        
+    
     return masks, variants_id, haplotypes
 
 

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -383,17 +383,17 @@ def process_vcf(snpobj, rs_ID_dict, rsid_or_chrompos):
     # Generate individual IDs for diploid samples
     ind_IDs = np.array([f"{sample}_{suffix}" for sample in samples for suffix in ["A", "B"]])
     
+    # Extract variant positions
     positions = snpobj['variants_pos'].tolist()
     
-    processed_IDs = rs_ID_dict.keys()
-    for i in range(len(variants_id)):
-        rs_ID = variants_id[i]
-        if (rs_ID in processed_IDs):
-            ref = rs_ID_dict[rs_ID]
-        else:
-            ref = ref_vcf[i]
-            rs_ID_dict[rs_ID] = ref
-        if ref != ref_vcf[i]:
+    # Process reference allele encoding
+    for i, (rs_ID, ref_val) in enumerate(zip(variants_id, ref_vcf)):
+        # If rs_ID isn't in the dictionary, it is set to ref_val
+        # Otherwise, it returns the existing value.
+        ref = rs_ID_dict.setdefault(rs_ID, ref_val)
+
+        # Flip genotype encoding if reference allele differs from stored reference
+        if ref != ref_val:
             calldata_gt[i, :] = 1 - calldata_gt[i, :]
     
     logging.info("VCF Processing Time: --- %s seconds ---" % (time.time() - start_time))

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -181,9 +181,9 @@ def process_tsv_fb(tsv_file, num_ancestries, prob_thresh, variants_pos, calldata
     return ancestry_matrix, calldata_gt, variants_id
 
 
-def process_tsv_msp(laiobj, variants_pos, variants_chrom, calldata_gt, variants_id):
+def process_laiobj(laiobj, variants_pos, variants_chrom, calldata_gt, variants_id):
     """                                                                                       
-    Process the TSV/MSP file to extract ancestry information.
+    Process the LocalAncestryObject to extract ancestry information.
 
     This function processes a LocalAncestryObject containing ancestry segment data. 
     It aligns the ancestry data with the provided genomic positions and 
@@ -493,7 +493,7 @@ def get_masked_matrix(snpobj, beagle_or_vcf, laiobj, vit_or_fbk_or_fbtsv_or_mspt
         
     if is_masked and vit_or_fbk_or_fbtsv_or_msptsv != 0:
         
-        ancestry_matrix, calldata_gt, variants_id = process_tsv_msp(laiobj, positions, snpobj['variants_chrom'], calldata_gt, variants_id)
+        ancestry_matrix, calldata_gt, variants_id = process_laiobj(laiobj, positions, snpobj['variants_chrom'], calldata_gt, variants_id)
 
         if vit_or_fbk_or_fbtsv_or_msptsv == 1 or vit_or_fbk_or_fbtsv_or_msptsv == 2:
             unique_ancestries = [str(i) for i in np.arange(1, num_ancestries+1)]

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -615,15 +615,20 @@ def process_labels_weights(
     handling group-based adjustments.
 
     Steps:
-      1. Load label/weight data and convert 'indID' to string type.
-      2. Build a fast lookup dictionary for haplotype indices.
-      3. Handle strand averaging or duplication.
-      4. Align genotype matrix columns with the filtered/processed 'indID's.
-      5. Apply or default weights (if is_weighted).
-      6. Remove unwanted labels and individuals based on min_percent_snps.
-      7. Remove individuals with zero weight.
-      8. Combine individuals if 'combination' > 0, adding new columns in one step.
-      9. Update mask, haplotypes, labels, weights, and optionally save.
+      1. Load label/weight data: Read labels from a `.tsv` file and convert individual identifiers (`indID`) to string.
+      2. Align genotype matrix columns: Reorder columns in the genotype matrix (`mask[ancestry]`) to match 
+         the sequence of individuals (`indID`) from the labels file.
+      3. Assign weights: If `is_weighted=True`, assign weights from the `combination_weight` column of `labels_file`; 
+         otherwise, all individuals receive a default weight of `1.0`.
+      4. Filter individuals based on SNP coverage (`min_percent_snps`) and remove unwanted groups: 
+         Compute the percentage of non-missing SNPs per individual from `mask[ancestry]`. Any individual 
+         with SNP coverage below `min_percent_snps` is removed. Additionally, individuals belonging to 
+         groups listed in `groups_to_remove` are excluded by setting their weight to `0`.
+      5. Remove individuals with zero weight: After filtering, any remaining individuals with a weight of `0` 
+         are removed from `mask[ancestry]`, `haplotypes`, `labels`, and `weights`.
+      6. Identify individuals assigned to the same `combination` group, average their genotype data, and create a new merged individual. 
+         The new entry is appended to `mask[ancestry]`, and its weight is assigned using `combination_weight`.
+      7. Update and optionally save the processed mask, haplotypes, labels, and weights.
 
     Args:
         labels_file (str, optional): 

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -578,7 +578,7 @@ def get_masked_matrix(snpobj, beagle_or_vcf, laiobj, vit_or_fbk_or_fbtsv_or_mspt
     return masked_matrices, ind_IDs, variants_id, rs_ID_dict
 
 
-def array_process(snpobj, laiobj, average_strands, prob_thresh, is_masked, rsid_or_chrompos, num_arrays=1): 
+def array_process(snpobj, laiobj, average_strands, is_masked, rsid_or_chrompos, num_arrays=1): 
     """                                                                                       
     Dataset processing of each of the individual arrays.                                               
                                                                                                
@@ -598,8 +598,6 @@ def array_process(snpobj, laiobj, average_strands, prob_thresh, is_masked, rsid_
     num_ancestries   : Number of unique ancestries in dataset. 
     average_strands  : boolean
                        Indicates whether to combine haplotypes for each individual.
-    prob_thresh      : float  
-                       Probability threshold for ancestry assignment.
     is_masked        : boolean
                        indicates if output matrix needs to be masked. 
     save_masks       : boolean

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -504,7 +504,6 @@ def get_masked_matrix(
         snpobj, 
         laiobj, 
         vit_or_fbk_or_fbtsv_or_msptsv,
-        is_mixed, 
         is_masked, 
         num_ancestries, 
         average_strands, 
@@ -524,8 +523,6 @@ def get_masked_matrix(
             Local ancestry inference object, used for ancestry-based masking.
         vit_or_fbk_or_fbtsv_or_msptsv (int): 
             Indicator for ancestry file type (1 = vit, 2 = fbk, 3 = fbtsv, 4 = msptsv).
-        is_mixed (bool): 
-            Whether the ancestry inference method allows for mixed ancestry representations.
         is_masked (bool): 
             Whether ancestry-based masking should be applied.
         num_ancestries (int): 
@@ -613,8 +610,6 @@ def array_process(snpobj, laiobj, average_strands, is_masked, rsid_or_chrompos, 
     """
     vit_or_fbk_or_fbtsv_or_msptsv_list = [4]
 
-    is_mixed = False
-
     # Initialization:
     rs_ID_dict = {}
     masks =[]
@@ -628,10 +623,9 @@ def array_process(snpobj, laiobj, average_strands, is_masked, rsid_or_chrompos, 
         logging.info("------ Array "+ str(i+1) + " Processing: ------")
         genome_matrix, ind_IDs, variants_id, rs_ID_dict = get_masked_matrix(snpobj, 
                                                                        laiobj,
-                                                                       vit_or_fbk_or_fbtsv_or_msptsv_list[i], is_mixed, is_masked,
+                                                                       vit_or_fbk_or_fbtsv_or_msptsv_list[i], is_masked,
                                                                        num_ancestries, average_strands, rs_ID_dict,
                                                                        rsid_or_chrompos)
-
 
         masks.append(genome_matrix)
         rs_ID_list.append(variants_id)

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -413,27 +413,31 @@ def process_vcf(snpobj, rs_ID_dict, rsid_or_chrompos):
     return calldata_gt, ind_IDs, variants_id, positions, rs_ID_dict
 
 
-def average_parent_snps(ancestry_matrix):
+def average_parent_snps(masked_ancestry_matrix):
     """                                                                                       
     Average haplotypes to obtain genotype data for individuals. 
     
     This function combines pairs of haplotypes by computing their mean.
 
     Args:
-        ancestry_matrix (np.ndarray of shape (n_snps, n_haplotypes)): 
-            The masked matrix for an ancestry, where `m` represents the number of SNPs and `n` 
-            represents the number of haplotypes.
+        masked_ancestry_matrix (np.ndarray of shape (n_snps, n_haplotypes)): 
+            The masked matrix for an ancestry, where `n_snps` represents the number of SNPs and 
+            `n_haplotypes` represents the number of haplotypes.
 
     Returns:
-        np.ndarray of shape (m, n/2):  
+        np.ndarray of shape (n_snps, n_samples):  
             A new matrix where each pair of haplotypes has been averaged, resulting in genotype 
             data for individuals instead of haplotypes.
     """
     start = time.time()
-    new_matrix = np.zeros((ancestry_matrix.shape[0], int(ancestry_matrix.shape[1]/2)), dtype = np.float16)
-    for i in range(0, ancestry_matrix.shape[1],2):
-        new_matrix[:, int(i/2)] = np.nanmean(ancestry_matrix[:,i:i+2],axis=1, dtype = np.float16)
+    # Initialize a new matrix with half the number of columns
+    new_matrix = np.zeros((masked_ancestry_matrix.shape[0], int(masked_ancestry_matrix.shape[1]/2)), dtype = np.float16)
+    
+    # Iterate through haplotype pairs, computing the mean for each pair
+    for i in range(0, masked_ancestry_matrix.shape[1], 2):
+        new_matrix[:, int(i/2)] = np.nanmean(masked_ancestry_matrix[:,i:i+2],axis=1, dtype = np.float16)
     logging.info("Combining time --- %s seconds ---" % (time.time() - start))
+    
     return new_matrix
 
 
@@ -446,7 +450,8 @@ def mask(ancestry_matrix, calldata_gt, unique_ancestries, ancestry_int_list, ave
 
     Args:
         ancestry_matrix (np.ndarray of shape (n_snps, n_haplotypes)): 
-            Matrix indicating the ancestry assignment for individual `n_haplotypes` at position `n_snps`.
+            Matrix indicating the ancestry assignments, where `n_snps` represents the number of SNPs and 
+            `n_haplotypes` represents the number of haplotypes.
         calldata_gt (np.ndarray of shape (n_snps, n_haplotypes)): 
             Genetic matrix encoding the genotype information for haplotypes.
         unique_ancestries (list): 
@@ -496,7 +501,7 @@ def mask(ancestry_matrix, calldata_gt, unique_ancestries, ancestry_int_list, ave
 
 
 def get_masked_matrix(snpobj, beagle_or_vcf, laiobj, vit_or_fbk_or_fbtsv_or_msptsv,
-                      is_mixed, is_masked, num_ancestries, average_strands, prob_thresh, rs_ID_dict, rsid_or_chrompos):
+                      is_mixed, is_masked, num_ancestries, average_strands, rs_ID_dict, rsid_or_chrompos):
     """                                                                                       
     Input Parameter Parser                                                
                                                                                                
@@ -634,7 +639,7 @@ def array_process(snpobj, laiobj, average_strands, prob_thresh, is_masked, rsid_
         genome_matrix, ind_IDs, variants_id, rs_ID_dict = get_masked_matrix(snpobj, beagle_or_vcf_list[i],
                                                                        laiobj,
                                                                        vit_or_fbk_or_fbtsv_or_msptsv_list[i], is_mixed, is_masked,
-                                                                       num_ancestries, average_strands, prob_thresh, rs_ID_dict,
+                                                                       num_ancestries, average_strands, rs_ID_dict,
                                                                        rsid_or_chrompos)
 
 

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -624,9 +624,11 @@ def process_labels_weights(
         min_percent_snps (float): 
             Minimum percentage of SNPs that must be known for an individual to be included in the analysis.
             All individuals with fewer percent of unmasked SNPs than this threshold will be excluded.
-        min_percent_snps (float, default=4): 
-                Minimum percentage of SNPs that must be known for an individual and of the ancesstry of interet to be included in the analysis.
-                All individuals with fewer percent of unmasked SNPs than this threshold will be excluded.
+        group_snp_frequencies_only (bool):
+            If True, mdPCA is performed exclusively on group-level SNP frequencies, ignoring individual-level data. This applies when `is_weighted` is 
+            set to True and a `combination` column is provided in the `labels_file`,  meaning individuals are aggregated into groups based on their assigned 
+            labels. If False, mdPCA is performed on individual-level SNP data alone or on both individual-level and group-level SNP frequencies when 
+            `is_weighted` is True and a `combination` column is provided.
         groups_to_remove (list of str): 
             List with groups to exclude from analysis. Example: ['group1', 'group2'].
         is_weighted (bool): 

--- a/snputils/processing/_utils/gen_tools.py
+++ b/snputils/processing/_utils/gen_tools.py
@@ -185,9 +185,9 @@ def process_tsv_msp(laiobj, variants_pos, variants_chrom, calldata_gt, variants_
     """                                                                                       
     Process the TSV/MSP file to extract ancestry information.
 
-    This function processes a TSV-formatted Local Ancestry Inference (LAI) object 
-    containing ancestry segment data. It aligns the ancestry data with the provided 
-    genomic positions and assigns ancestry labels accordingly.
+    This function processes a LocalAncestryObject containing ancestry segment data. 
+    It aligns the ancestry data with the provided genomic positions and 
+    assigns ancestry labels accordingly.
 
     Args:
         laiobj (dict): 
@@ -214,26 +214,37 @@ def process_tsv_msp(laiobj, variants_pos, variants_chrom, calldata_gt, variants_
     """
     start_time = time.time()
     
+    # Extract start and end positions of ancestry segments
     tsv_spos = laiobj['physical_pos'][:,0].tolist()
     tsv_epos = laiobj['physical_pos'][:,1].tolist()
+    
+    # Extract ancestry matrix from LAI object
     tsv_matrix = laiobj['lai']
 
+    # Determine index range for matching positions
     i_start = variants_pos.index(tsv_spos[0])
     if tsv_epos[-1] in variants_pos:
         i_end = variants_pos.index(tsv_epos[-1])
     else:
         i_end = len(variants_pos)
     
+    # Update genotype matrix and associated metadata
     calldata_gt = calldata_gt[i_start:i_end, :]
     variants_pos = variants_pos[i_start:i_end]
     variants_id = variants_id[i_start:i_end]
 
+    # Extract chromosome information from LAI object
     tsv_chromosomes = laiobj['chromosomes']
+
+     # Initialize ancestry matrix
     ancestry_matrix = np.zeros((len(variants_pos), tsv_matrix.shape[1]), dtype=np.int8)
+
+    # Variables for iterating through ancestry data
     i_tsv = -1
     next_pos_tsv = tsv_spos[i_tsv+1]
     next_chrom_tsv = tsv_chromosomes[i_tsv+1]
 
+    # Assign ancestry based on genomic position and chromosome alignment
     for i, pos in enumerate(variants_pos):
         if pos >= next_pos_tsv and int(variants_chrom[i]) == int(next_chrom_tsv) and i_tsv + 1 < tsv_matrix.shape[0]:
             i_tsv += 1
@@ -244,6 +255,7 @@ def process_tsv_msp(laiobj, variants_pos, variants_chrom, calldata_gt, variants_
 
         ancestry_matrix[i, :] = ancs
 
+    # Convert ancestry matrix to string format
     ancestry_matrix = ancestry_matrix.astype(str)
     
     logging.info("TSV Processing Time: --- %s seconds ---" % (time.time() - start_time))

--- a/snputils/processing/_utils/mds_distance.py
+++ b/snputils/processing/_utils/mds_distance.py
@@ -595,7 +595,7 @@ def mds_transform(distance_list, groups, weights, ind_ID_list, num_dims, num_arr
     -------                                                                                   
     None
     """
-    ind_IDs = ind_ID_list[0]
+    ind_IDs = ind_ID_list
     for i in range(1,num_arrays):
         ind_IDs = np.hstack((ind_IDs, ind_ID_list[i]))
     

--- a/snputils/processing/maasmds.py
+++ b/snputils/processing/maasmds.py
@@ -50,7 +50,8 @@ class maasMDS:
             ancestry (str, optional): 
                 Ancestry for which dimensionality reduction is to be performed. Ancestry counter starts at `0`.
             is_masked (bool, default=True): 
-                True if an ancestry file is passed for ancestry-specific masking, or False otherwise.
+                If `True`, applies ancestry-specific masking to the genotype matrix, retaining only genotype data 
+                corresponding to the specified `ancestry`. If `False`, uses the full, unmasked genotype matrix.
             average_strands (bool, default=False): 
                 True if the haplotypes from the two parents are to be combined (averaged) for each individual, or False otherwise.
             is_weighted (bool, default=False): 

--- a/snputils/processing/maasmds.py
+++ b/snputils/processing/maasmds.py
@@ -88,7 +88,7 @@ class maasMDS:
         self.__snpobj = snpobj
         self.__laiobj = laiobj
         self.__labels_file = labels_file
-        self.__ancestry = ancestry
+        self.__ancestry = self._define_ancestry(ancestry, laiobj.ancestry_map)
         self.__is_masked = is_masked
         self.__average_strands = average_strands
         self.__force_nan_incomplete_strands = force_nan_incomplete_strands
@@ -558,6 +558,30 @@ class maasMDS:
                 (`min_percent_snps > 0`).
         """
         return len(np.unique(self.samples_))
+
+    @staticmethod
+    def _define_ancestry(ancestry, ancestry_map):
+        """
+        Determine the ancestry index based on different input types.
+
+        Args:
+            ancestry (int or str): The ancestry input, which can be:
+                - An integer (e.g., 0, 1, 2).
+                - A string representation of an integer (e.g., '0', '1').
+                - A string matching one of the ancestry map values (e.g., 'Africa').
+            ancestry_map (dict): A dictionary mapping ancestry indices (as strings) to ancestry names.
+
+        Returns:
+            int: The corresponding ancestry index.
+        """
+        if isinstance(ancestry, int):  
+            return ancestry  
+        elif isinstance(ancestry, str) and ancestry.isdigit():  
+            return int(ancestry)  
+        elif ancestry in ancestry_map.values():  
+            return int(next(key for key, value in ancestry_map.items() if value == ancestry))  
+        else:  
+            raise ValueError(f"Invalid ancestry input: {ancestry}")
 
     @staticmethod
     def _load_masks_file(masks_file):

--- a/snputils/processing/maasmds.py
+++ b/snputils/processing/maasmds.py
@@ -569,7 +569,7 @@ class maasMDS:
                 self.masks_file
             )
         
-        distance_list = [[distance_mat(first=masks[0][self.ancestry], dist_func=self.distance_type)]]
+        distance_list = [[distance_mat(first=masks[self.ancestry], dist_func=self.distance_type)]]
         
         self.X_new_ = mds_transform(distance_list, groups, weights, ind_ID_list, self.n_components)
         self.haplotypes_ = ind_ID_list

--- a/snputils/processing/maasmds.py
+++ b/snputils/processing/maasmds.py
@@ -6,7 +6,7 @@ from typing import Optional, Dict, List, Union
 from snputils.snp.genobj.snpobj import SNPObject
 from snputils.ancestry.genobj.local import LocalAncestryObject
 from ._utils.mds_distance import distance_mat, mds_transform
-from ._utils.gen_tools import array_process, process_labels_weights
+from ._utils.gen_tools import get_masked_matrix, process_labels_weights
 
 
 class maasMDS:
@@ -547,7 +547,7 @@ class maasMDS:
         if self.load_masks:
             masks, rs_ID_list, ind_ID_list, groups, weights = self._load_masks_file(self.masks_file)
         else:
-            masks, rs_ID_list, ind_ID_list = array_process(
+            masks, rs_ID_list, ind_ID_list = get_masked_matrix(
                 self.snpobj,
                 self.laiobj,
                 self.average_strands,

--- a/snputils/processing/maasmds.py
+++ b/snputils/processing/maasmds.py
@@ -25,7 +25,6 @@ class maasMDS:
             labels_file,
             ancestry,
             is_masked: bool = True,
-            prob_thresh: float = 0,
             average_strands: bool = False,
             is_weighted: bool = False,
             groups_to_remove: Dict[int, List[str]] = {},
@@ -52,8 +51,6 @@ class maasMDS:
                 Ancestry for which dimensionality reduction is to be performed. Ancestry counter starts at `0`.
             is_masked (bool, default=True): 
                 True if an ancestry file is passed for ancestry-specific masking, or False otherwise.
-            prob_thresh (float, default=0.0): 
-                Minimum probability threshold for a SNP to belong to an ancestry.
             average_strands (bool, default=False): 
                 True if the haplotypes from the two parents are to be combined (averaged) for each individual, or False otherwise.
             is_weighted (bool, default=False): 
@@ -84,7 +81,6 @@ class maasMDS:
         self.__labels_file = labels_file
         self.__ancestry = ancestry
         self.__is_masked = is_masked
-        self.__prob_thresh = prob_thresh
         self.__average_strands = average_strands
         self.__groups_to_remove = groups_to_remove
         self.__min_percent_snps = min_percent_snps
@@ -218,23 +214,6 @@ class maasMDS:
         Update `is_masked`.
         """
         self.__is_masked = x
-
-    @property
-    def prob_thresh(self) -> float:
-        """
-        Retrieve `prob_thresh`.
-        
-        Returns:
-            **float:** Minimum probability threshold for a SNP to belong to an ancestry.
-        """
-        return self.__prob_thresh
-
-    @prob_thresh.setter
-    def prob_thresh(self, x: float) -> None:
-        """
-        Update `prob_thresh`.
-        """
-        self.__prob_thresh = x
 
     @property
     def average_strands(self) -> bool:
@@ -571,7 +550,6 @@ class maasMDS:
                 self.snpobj,
                 self.laiobj,
                 self.average_strands,
-                self.prob_thresh, 
                 self.is_masked, 
                 self.rsid_or_chrompos
             )

--- a/snputils/processing/mdpca.py
+++ b/snputils/processing/mdpca.py
@@ -131,7 +131,7 @@ class mdPCA:
         self.__haplotypes_ = None  # Store haplotypes of X_new_ (after filtering if min_percent_snps > 0)
         self.__samples_ = None  # Store samples of X_new_ (after filtering if min_percent_snps > 0)
         self.__variants_id_ = None  # Store variants ID (after filtering SNPs not in laiobj)
-        self.__variant
+        self.__variant = None
 
         # Fit and transform if a `snpobj`, `laiobj`, `labels_file`, and `ancestry` are provided
         if self.snpobj is not None and self.laiobj is not None and self.labels_file is not None and self.ancestry is not None:
@@ -598,9 +598,9 @@ class mdPCA:
         return copy.copy(self)
 
     def _process_masks(self, masks, rs_ID_list, ind_ID_list):
-        masked_matrix = masks[0][self.ancestry].T
-        rs_IDs = rs_ID_list[0]
-        ind_IDs = ind_ID_list[0]
+        masked_matrix = masks[self.ancestry].T
+        rs_IDs = rs_ID_list
+        ind_IDs = ind_ID_list
         return masked_matrix, rs_IDs, ind_IDs
 
     def _load_mask_file(self):
@@ -973,11 +973,10 @@ class mdPCA:
             average_strands = self.average_strands
         
         if self.load_masks:
-            # If `load_masks` is True, load precomputed ancestry-based masked genotype matrixes, SNP identifiers, 
-            # haplotype identifiers, and weights from the specified `masks_file`
+            # Load precomputed ancestry-based masked genotype matrixes, SNP identifiers, haplotype identifiers, and weights
             masks, variants_id, haplotypes, _, weights = self._load_mask_file()
         else:
-            # Compute ancestry-based masked genotype matrixes, SNP identifiers, and individual IDs
+            # Obtain ancestry-based masked genotype matrixes, SNP identifiers, and haplotype identifiers
             masks, variants_id, haplotypes = array_process(
                 self.snpobj,
                 self.laiobj,

--- a/snputils/processing/mdpca.py
+++ b/snputils/processing/mdpca.py
@@ -973,7 +973,6 @@ class mdPCA:
                 self.snpobj,
                 self.laiobj,
                 self.average_strands,
-                self.prob_thresh,
                 self.is_masked,
                 self.rsid_or_chrompos
             )

--- a/snputils/processing/mdpca.py
+++ b/snputils/processing/mdpca.py
@@ -123,7 +123,7 @@ class mdPCA:
         self.__snpobj = snpobj
         self.__laiobj = laiobj
         self.__labels_file = labels_file
-        self.__ancestry = ancestry
+        self.__ancestry = self._define_ancestry(ancestry, laiobj.ancestry_map)
         self.__method = method
         self.__is_masked = is_masked
         self.__average_strands = average_strands
@@ -646,6 +646,30 @@ class mdPCA:
                 A new instance of the current object.
         """
         return copy.copy(self)
+
+    @staticmethod
+    def _define_ancestry(ancestry, ancestry_map):
+        """
+        Determine the ancestry index based on different input types.
+
+        Args:
+            ancestry (int or str): The ancestry input, which can be:
+                - An integer (e.g., 0, 1, 2).
+                - A string representation of an integer (e.g., '0', '1').
+                - A string matching one of the ancestry map values (e.g., 'Africa').
+            ancestry_map (dict): A dictionary mapping ancestry indices (as strings) to ancestry names.
+
+        Returns:
+            int: The corresponding ancestry index.
+        """
+        if isinstance(ancestry, int):  
+            return ancestry  
+        elif isinstance(ancestry, str) and ancestry.isdigit():  
+            return int(ancestry)  
+        elif ancestry in ancestry_map.values():  
+            return int(next(key for key, value in ancestry_map.items() if value == ancestry))  
+        else:  
+            raise ValueError(f"Invalid ancestry input: {ancestry}")
 
     def _load_mask_file(self):
         """

--- a/snputils/processing/mdpca.py
+++ b/snputils/processing/mdpca.py
@@ -610,7 +610,7 @@ class mdPCA:
         Returns:
             **array of shape (n_snp,):** 
                 An array containing unique identifiers (IDs) for each SNP,
-                potentially reduced if there are SNPs not present in the `laiboj`.
+                potentially reduced if there are SNPs not present in the `laiobj`.
                 The format will depend on `rsid_or_chrompos`.
         """
         return self.__variants_id_

--- a/snputils/processing/mdpca.py
+++ b/snputils/processing/mdpca.py
@@ -103,7 +103,7 @@ class mdPCA:
             groups_to_remove (list of str, optional): 
                 List with groups to exclude from analysis. Example: ['group1', 'group2'].
             min_percent_snps (float, default=4): 
-                Minimum percentage of SNPs that must be known for an individual and of the ancesstry of interet to be included in the analysis.
+                Minimum percentage of SNPs that must be known for an individual and of the ancestry of interest to be included in the analysis.
                 All individuals with fewer percent of unmasked SNPs than this threshold will be excluded.
             group_snp_frequencies_only (bool, default=True):
                 If True, mdPCA is performed exclusively on group-level SNP frequencies, ignoring individual-level data. This applies when `is_weighted` is 

--- a/snputils/processing/mdpca.py
+++ b/snputils/processing/mdpca.py
@@ -78,7 +78,8 @@ class mdPCA:
             ancestry (str, optional): 
                 Ancestry for which dimensionality reduction is to be performed. Ancestry counter starts at `0`.
             is_masked (bool, default=True): 
-                True if an ancestry file is passed for ancestry-specific masking, or False otherwise.
+                If `True`, applies ancestry-specific masking to the genotype matrix, retaining only genotype data 
+                corresponding to the specified `ancestry`. If `False`, uses the full, unmasked genotype matrix.
             average_strands (bool, default=False): 
                 True if the haplotypes from the two parents are to be combined (averaged) for each individual, or False otherwise.
             is_weighted (bool, default=False): 

--- a/snputils/processing/mdpca.py
+++ b/snputils/processing/mdpca.py
@@ -33,6 +33,7 @@ class mdPCA:
         ancestry: Optional[str] = None,
         is_masked: bool = True,
         average_strands: bool = False,
+        force_nan_incomplete_strands: bool = False,
         is_weighted: bool = False,
         groups_to_remove: List[str] = None,
         min_percent_snps: float = 4,
@@ -88,6 +89,9 @@ class mdPCA:
                 corresponding to the specified `ancestry`. If `False`, uses the full, unmasked genotype matrix.
             average_strands (bool, default=False): 
                 True if the haplotypes from the two parents are to be combined (averaged) for each individual, or False otherwise.
+            force_nan_incomplete_strands (bool): 
+                If `True`, sets the result to NaN if either haplotype in a pair is NaN. 
+                Otherwise, computes the mean while ignoring NaNs (e.g., 0|NaN -> 0, 1|NaN -> 1).
             is_weighted (bool, default=False): 
                 If `True`, assigns individual weights from the `weight` column in `labels_file`. Otherwise, all individuals have equal weight of `1`.
             groups_to_remove (list of str, optional): 
@@ -123,6 +127,7 @@ class mdPCA:
         self.__method = method
         self.__is_masked = is_masked
         self.__average_strands = average_strands
+        self.__force_nan_incomplete_strands = force_nan_incomplete_strands
         self.__is_weighted = is_weighted
         self.__groups_to_remove = groups_to_remove
         self.__min_percent_snps = min_percent_snps
@@ -284,6 +289,24 @@ class mdPCA:
         self.__average_strands = x
 
     @property
+    def force_nan_incomplete_strands(self) -> bool:
+        """
+        Retrieve `force_nan_incomplete_strands`.
+        
+        Returns:
+            **bool**: If `True`, sets the result to NaN if either haplotype in a pair is NaN.
+                      Otherwise, computes the mean while ignoring NaNs (e.g., 0|NaN -> 0, 1|NaN -> 1).
+        """
+        return self.__force_nan_incomplete_strands
+
+    @force_nan_incomplete_strands.setter
+    def force_nan_incomplete_strands(self, x: bool) -> None:
+        """
+        Update `force_nan_incomplete_strands`.
+        """
+        self.__force_nan_incomplete_strands = x
+
+    @property
     def is_weighted(self) -> bool:
         """
         Retrieve `is_weighted`.
@@ -348,7 +371,7 @@ class mdPCA:
                 when `is_weighted` is True and `combined` is provided in the `labels_file`. False if mdPCA is to be 
                 performed using both individual-level and group-level data.
         """
-        return self.__min_percent_snps
+        return self.__group_snp_frequencies_only
 
     @group_snp_frequencies_only.setter
     def group_snp_frequencies_only(self, x: bool) -> None:
@@ -1003,6 +1026,7 @@ class mdPCA:
                 self.laiobj,
                 self.ancestry,
                 self.average_strands,
+                self.force_nan_incomplete_strands,
                 self.is_masked,
                 self.rsid_or_chrompos
             )

--- a/snputils/processing/mdpca.py
+++ b/snputils/processing/mdpca.py
@@ -17,12 +17,15 @@ from ._utils.iterative_svd import IterativeSVD
 
 class mdPCA:
     """
-    A class for missing data principal component analysis (mdPCA).
+    A class for performing missing data principal component analysis (mdPCA) on SNP data.
 
-    This class supports both separate and averaged strand processing for SNP data. If the `snpobj`, 
-    `laiobj`, `labels_file`, and `ancestry` parameters are all provided during instantiation, 
-    the `fit_transform` method will be automatically called, applying the specified mdPCA method to transform 
-    the data upon instantiation.
+    The mdPCA class focuses on genotype segments from the ancestry of interest when the `is_masked` flag is set to `True`. It offers 
+    flexible processing options, allowing either separate handling of masked haplotype strands or combining (averaging) strands into a 
+    single composite representation for each individual. Moreover, the analysis can be performed on individual-level data, group-level SNP 
+    frequencies, or a combination of both.
+
+    If the `snpobj`, `laiobj`, `labels_file`, and `ancestry` parameters are all provided during instantiation, the `fit_transform` method 
+    will be automatically called, applying the specified mdPCA method to transform the data upon instantiation.
     """
     def __init__(
         self,
@@ -30,7 +33,7 @@ class mdPCA:
         snpobj: Optional['SNPObject'] = None,
         laiobj: Optional['LocalAncestryObject'] = None,
         labels_file: Optional[str] = None,
-        ancestry: Optional[str] = None,
+        ancestry: Optional[Union[int, str]] = None,
         is_masked: bool = True,
         average_strands: bool = False,
         force_nan_incomplete_strands: bool = False,
@@ -82,8 +85,11 @@ class mdPCA:
                 must share the same `label` and `combination_weight`. If `combination_weight` column is not provided, the combinations are 
                 assigned a default weight of `1`. Individuals excluded via `groups_to_remove` or those falling below `min_percent_snps` are removed 
                 from the analysis.
-            ancestry (str, optional): 
-                Ancestry for which dimensionality reduction is to be performed. Ancestry counter starts at `0`.
+            ancestry (int or str, optional): 
+                Ancestry for which dimensionality reduction is to be performed. Ancestry counter starts at `0`. The ancestry input can be:
+                - An integer (e.g., 0, 1, 2).
+                - A string representation of an integer (e.g., '0', '1').
+                - A string matching one of the ancestry map values (e.g., 'Africa').
             is_masked (bool, default=True): 
                 If `True`, applies ancestry-specific masking to the genotype matrix, retaining only genotype data 
                 corresponding to the specified `ancestry`. If `False`, uses the full, unmasked genotype matrix.
@@ -100,8 +106,10 @@ class mdPCA:
                 Minimum percentage of SNPs that must be known for an individual and of the ancesstry of interet to be included in the analysis.
                 All individuals with fewer percent of unmasked SNPs than this threshold will be excluded.
             group_snp_frequencies_only (bool, default=True):
-                True if mdPCA is to be performed only on group-level SNP frequencies, excluding individual-level data, when `is_weighted` is True and 
-                `combined` is provided in the `labels_file`. False if mdPCA is to be performed using both individual-level and group-level data.
+                If True, mdPCA is performed exclusively on group-level SNP frequencies, ignoring individual-level data. This applies when `is_weighted` is 
+                set to True and a `combination` column is provided in the `labels_file`,  meaning individuals are aggregated into groups based on their assigned 
+                labels. If False, mdPCA is performed on individual-level SNP data alone or on both individual-level and group-level SNP frequencies when 
+                `is_weighted` is True and a `combination` column is provided.
             save_masks (bool, default=False): 
                 True if the masked matrices are to be saved in a `.npz` file, or False otherwise.
             load_masks (bool, default=False): 
@@ -367,9 +375,10 @@ class mdPCA:
         
         Returns:
             **bool:** 
-                True if mdPCA is to be performed only on group-level SNP frequencies, excluding individual-level data, 
-                when `is_weighted` is True and `combined` is provided in the `labels_file`. False if mdPCA is to be 
-                performed using both individual-level and group-level data.
+                If True, mdPCA is performed exclusively on group-level SNP frequencies, ignoring individual-level data. This applies 
+                when `is_weighted` is set to True and a `combination` column is provided in the `labels_file`,  meaning individuals are 
+                aggregated into groups based on their assigned labels. If False, mdPCA is performed on individual-level SNP data alone 
+                or on both individual-level and group-level SNP frequencies when `is_weighted` is True and a `combination` column is provided.
         """
         return self.__group_snp_frequencies_only
 

--- a/snputils/processing/mdpca.py
+++ b/snputils/processing/mdpca.py
@@ -11,7 +11,7 @@ from sklearn.decomposition import TruncatedSVD
 
 from snputils.snp.genobj.snpobj import SNPObject
 from snputils.ancestry.genobj.local import LocalAncestryObject
-from ._utils.gen_tools import array_process, process_labels_weights
+from ._utils.gen_tools import get_masked_matrix, process_labels_weights
 from ._utils.iterative_svd import IterativeSVD
 
 
@@ -977,7 +977,7 @@ class mdPCA:
             masks, variants_id, haplotypes, _, weights = self._load_mask_file()
         else:
             # Obtain ancestry-based masked genotype matrixes, SNP identifiers, and haplotype identifiers
-            masks, variants_id, haplotypes = array_process(
+            masks, variants_id, haplotypes = get_masked_matrix(
                 self.snpobj,
                 self.laiobj,
                 self.average_strands,

--- a/snputils/processing/mdpca.py
+++ b/snputils/processing/mdpca.py
@@ -32,7 +32,6 @@ class mdPCA:
         labels_file: Optional[str] = None,
         ancestry: Optional[str] = None,
         is_masked: bool = True,
-        prob_thresh: float = 0,
         average_strands: bool = False,
         is_weighted: bool = False,
         groups_to_remove: Dict[int, List[str]] = {},
@@ -80,8 +79,6 @@ class mdPCA:
                 Ancestry for which dimensionality reduction is to be performed. Ancestry counter starts at `0`.
             is_masked (bool, default=True): 
                 True if an ancestry file is passed for ancestry-specific masking, or False otherwise.
-            prob_thresh (float, default=0): 
-                Minimum probability threshold for a SNP to belong to an ancestry.
             average_strands (bool, default=False): 
                 True if the haplotypes from the two parents are to be combined (averaged) for each individual, or False otherwise.
             is_weighted (bool, default=False): 
@@ -117,7 +114,6 @@ class mdPCA:
         self.__ancestry = ancestry
         self.__method = method
         self.__is_masked = is_masked
-        self.__prob_thresh = prob_thresh
         self.__average_strands = average_strands
         self.__is_weighted = is_weighted
         self.__groups_to_remove = groups_to_remove
@@ -259,22 +255,6 @@ class mdPCA:
         Update `is_masked`.
         """
         self.__is_masked = x
-
-    @property
-    def prob_thresh(self) -> float:
-        """
-        Retrieve `prob_thresh`.
-        
-        Returns:
-            **float:** Minimum probability threshold for a SNP to belong to an ancestry.
-        """
-        return self.__prob_thresh
-
-    @prob_thresh.setter
-    def prob_thresh(self, x: float) -> None:
-        """Update `prob_thresh`.
-        """
-        self.__prob_thresh = x
 
     @property
     def average_strands(self) -> bool:

--- a/snputils/visualization/scatter_plot.py
+++ b/snputils/visualization/scatter_plot.py
@@ -44,6 +44,9 @@ def scatter(
     # Load labels from TSV
     labels_df = pd.read_csv(labels_file, sep='\t')
 
+    # Ensure 'indID' is treated as a string
+    labels_df['indID'] = labels_df['indID'].astype(str)
+
     # Filter labels based on the indIDs in dimredobj
     sample_ids = dimredobj.samples_
     filtered_labels_df = labels_df[labels_df['indID'].isin(sample_ids)]


### PR DESCRIPTION
#### Bug Fixes
* Fixed issue when reading labels file where all indID values were integers.
* Ensured individuals from excluded groups are properly removed from analysis.

#### New Features & Parameter Updates
* Added `group_snp_frequencies_only` parameter, allowing mdPCA and maasMDS to run on group-level SNP frequencies instead of both group-level SNP frequencies and individual-level data.
* Added `force_nan_incomplete_strands` parameter, controlling whether SNPs with missing haplotype data are set to NaN when averaging the strrands.
* Improved handling of ancestry codes, allowing both string names and numerical representations for ancestry selection.
* Stored `self.variants_id_` attribute, ensuring SNP identifiers are accessible.

#### Code Improvements
* Removed unused variables and parameters to clean up the codebase.
* Merged redundant functions to improve maintainability.

#### Performance & Memory Optimization
* Optimized computational efficiency by only masking genotypes for ancestry of interest.
* Optimized window-level ancestry assignment for better performance. Improved `convert_to_snp_level` from LocalAncestryObject.
* Removed external lists from masks, variants_id, and haplotypes.
* Removed unnecessary parameters such as `prob_thresh` and `n_ancestries`.

#### Documentation
* Improved function and class documentation across the codebase.
* Renamed variables for clarity.
* Improved demo notebook.