### PR TITLE
Add methods to merge/concat SNPObjects and for strand summation

### DIFF
--- a/snputils/snp/genobj/snpobj.py
+++ b/snputils/snp/genobj/snpobj.py
@@ -257,8 +257,9 @@ class SNPObject:
         Retrieve `calldata_lai`.
 
         Returns:
-            **array of shape (n_snps, n_samples, 2):** 
-                An array containing the ancestry for each SNP.
+            **array:** 
+                An array containing the ancestry for each SNP. This array can be either 2D with shape
+                `(n_snps, n_samples*2)`, or 3D with shape (n_snps, n_samples, 2).
         """
         return self.__calldata_lai
 

--- a/snputils/snp/genobj/snpobj.py
+++ b/snputils/snp/genobj/snpobj.py
@@ -300,7 +300,10 @@ class SNPObject:
         elif self.__calldata_gt is not None:
             return self.__calldata_gt.shape[1]
         elif self.__calldata_lai is not None:
-            return self.__calldata_lai.shape[1]
+            if self.__calldata_lai.ndim == 2:
+                return self.__calldata_lai.shape[1] // 2
+            elif self.__calldata_lai.ndim == 3:
+                return self.__calldata_lai.shape[1]
         else:
             raise ValueError("Unable to determine the total number of samples: no relevant data is available.")
 
@@ -1452,7 +1455,7 @@ class SNPObject:
         if window_size is None and physical_pos is None and laiobj is None:
             raise ValueError("One of `window_size`, `physical_pos`, or `laiobj` must be provided.")
         
-        # 1. Fixed window size
+        # Fixed window size
         if window_size is not None:
             physical_pos = []   # Boundaries [start, end] of each window
             chromosomes = []    # Chromosome for each window
@@ -1489,7 +1492,7 @@ class SNPObject:
             chromosomes = np.array(chromosomes)
             window_sizes = np.array(window_sizes)
         
-        # 2. Custom start and end positions
+        # Custom start and end positions
         elif physical_pos is not None:
             # Check if there is exactly one chromosome
             if chromosomes is None:
@@ -1501,7 +1504,7 @@ class SNPObject:
                 else:
                     raise ValueError("Multiple chromosomes detected, but `chromosomes` was not provided.")
 
-        # 3. Match existing windows to a reference laiobj
+        # Match existing windows to a reference laiobj
         elif laiobj is not None:
             physical_pos = laiobj.physical_pos
             chromosomes = laiobj.chromosomes

--- a/snputils/snp/genobj/snpobj.py
+++ b/snputils/snp/genobj/snpobj.py
@@ -1513,7 +1513,7 @@ class SNPObject:
         # Allocate an output LAI array
         n_windows = physical_pos.shape[0]
         n_samples = self.n_samples
-        if len(self.calldata_lai.shape) == 3:
+        if self.calldata_lai.ndim == 3:
             lai = np.zeros((n_windows, n_samples, 2))
         else:
             lai = np.zeros((n_windows, n_samples*2))
@@ -1536,7 +1536,7 @@ class SNPObject:
         haplotypes = [f"{sample}.{i}" for sample in self.samples for i in range(2)]
 
         # If original data was (n_snps, n_samples, 2), flatten to (n_windows, n_samples*2)
-        if len(self.calldata_lai.shape) == 3:
+        if self.calldata_lai.ndim == 3:
             lai = lai.reshape(n_windows, -1)
 
         # Aggregate into a LocalAncestryObject


### PR DESCRIPTION
This PR adds three new methods to the **SNPObject**:

* `merge`: Merges samples from another SNPObject, assuming both objects contain the same SNPs in the same order. Includes a `force_samples` parameter to handle cases where there are duplicated samples.
* `concat`: Concatenates SNPs from another SNPObject, assuming both objects share the same samples in the same order. The second object must contain SNPs from a higher chromosome number.
* `sum_strands`: Sums genotype maternal and paternalstrands.