### PR TITLE
bug fix - psam specifications require that first column starts with #…

### DIFF
--- a/snputils/snp/io/write/pgen.py
+++ b/snputils/snp/io/write/pgen.py
@@ -108,7 +108,7 @@ class PGENWriter:
         log.info(f"Writing {self.__filename}.psam")
         df = pl.DataFrame(
             {
-                "IID": self.__snpobj.samples,
+                "#IID": self.__snpobj.samples,
                 "SEX": "NA",  # Add SEX as nan for now
                 # TODO: add SEX as Optional column to SNPObject and write it to the .psam file (if not it's lost)
             }


### PR DESCRIPTION
…IID and not IID

bug fix - psam specifications require that first column starts with #IID and not IID