### PR TITLE
Add __version__ attribute to snputils

### DIFF
--- a/snputils/__init__.py
+++ b/snputils/__init__.py
@@ -1,3 +1,11 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("snputils")
+except PackageNotFoundError:
+    # package is not installed
+    __version__ = "unknown"
+
 from .snp import SNPObject, SNPReader, BEDReader, PGENReader, VCFReader, BEDWriter, PGENWriter, VCFWriter, read_snp, read_bed, read_pgen, read_vcf
 from .ancestry import LocalAncestryObject, GlobalAncestryObject, MSPReader, MSPWriter, AdmixtureMappingVCFWriter, AdmixtureReader, AdmixtureWriter, read_lai, read_msp, read_adm, read_admixture
 from .phenotype import MultiPhenotypeObject, UKBPhenotypeObject, MultiPhenTabularReader, UKBPhenReader


### PR DESCRIPTION
## Add `__version__` attribute to snputils

Adds `__version__` attribute to allow version checking via `snputils.__version__` instead of requiring `importlib.metadata.version("snputils")`.

### Changes
- Modified `snputils/__init__.py` to expose version via `__version__`
- Added error handling for uninstalled package scenarios