### PR TITLE
Admixture fixes

### DIFF
--- a/snputils/ancestry/genobj/wide.py
+++ b/snputils/ancestry/genobj/wide.py
@@ -66,10 +66,11 @@ class GlobalAncestryObject(AncestryObject):
                     f"Length of snps ({len(snps)}) does not match number of SNPs ({n_snps})."
                 )
 
-        if len(ancestries) != n_samples:
-            raise ValueError(
-                f"Length of ancestries ({len(ancestries)}) does not match number of samples ({n_samples})."
-            )
+        if ancestries is not None:
+            if len(ancestries) != n_samples:
+                raise ValueError(
+                    f"Length of ancestries ({len(ancestries)}) does not match number of samples ({n_samples})."
+                )
 
         super().__init__(n_samples, n_ancestries)
 
@@ -78,7 +79,7 @@ class GlobalAncestryObject(AncestryObject):
         self.__P = P
         self.__samples = np.asarray(samples)
         self.__snps = np.asarray(snps)
-        self.__ancestries = np.asarray(ancestries)
+        self.__ancestries = np.asarray(ancestries) if ancestries is not None else None
 
         # Perform sanity checks
         self._sanity_check()
@@ -245,7 +246,7 @@ class GlobalAncestryObject(AncestryObject):
             raise ValueError(
                 f"ancestries must have length {self.n_samples}; got length {num_x}."
             )
-        if num_unique_x <= self.n_ancestries:
+        if num_unique_x > self.n_ancestries:
             raise ValueError(
                 f"Number of unique ancestry labels must be less than or equal to {self.n_ancestries}; got {num_unique_x} unique labels."
             )
@@ -343,7 +344,7 @@ class GlobalAncestryObject(AncestryObject):
 
             # Check number of unique ancestry labels
             num_unique_ancestries = len(np.unique(self.__ancestries))
-            if num_unique_ancestries <= self.n_ancestries:
+            if num_unique_ancestries > self.n_ancestries:
                 raise ValueError(
                     f"Number of unique ancestry labels must be less than or equal to {self.n_ancestries}; got {num_unique_ancestries} unique labels."
                 )

--- a/snputils/ancestry/io/wide/read/admixture.py
+++ b/snputils/ancestry/io/wide/read/admixture.py
@@ -16,7 +16,7 @@ class AdmixtureReader(WideBaseReader):
     def __init__(
         self,
         Q_file: Union[str, Path],
-        P_file: Union[str, Path],
+        P_file: Optional[Union[str, Path]] = None,
         sample_file: Optional[Union[str, Path]] = None,
         snp_file: Optional[Union[str, Path]] = None,
         ancestry_file: Optional[Union[str, Path]] = None,
@@ -27,10 +27,10 @@ class AdmixtureReader(WideBaseReader):
                 Path to the file containing the Q matrix (per-sample ancestry proportions).
                 It should end with .Q or .txt.
                 The file should use space (' ') as the delimiter.
-            P_file (str or pathlib.Path):
+            P_file (str or pathlib.Path, optional):
                 Path to the file containing the P/F matrix (per-ancestry SNP frequencies).
                 It should end with .P or .txt.
-                The file should use space (' ') as the delimiter.
+                The file should use space (' ') as the delimiter. If None, P is not loaded.
             sample_file (str or pathlib.Path, optional):
                 Path to the single-column file containing sample identifiers. 
                 It should end with .fam or .txt.
@@ -45,7 +45,7 @@ class AdmixtureReader(WideBaseReader):
                 If None, ancestries are not loaded.
         """
         self.__Q_file = Path(Q_file)
-        self.__P_file = Path(P_file)
+        self.__P_file = Path(P_file) if P_file is not None else None
         self.__sample_file = Path(sample_file) if sample_file is not None else None
         self.__snp_file = Path(snp_file) if snp_file is not None else None
         self.__ancestry_file = Path(ancestry_file) if ancestry_file is not None else None
@@ -64,15 +64,15 @@ class AdmixtureReader(WideBaseReader):
         return self.__Q_file
 
     @property
-    def P_file(self) -> Path:
+    def P_file(self) -> Optional[Path]:
         """
         Retrieve P_file.
 
         Returns:
-            **pathlib.Path:** 
+            **pathlib.Path or None:** 
                 Path to the file containing the P/F matrix (per-ancestry SNP frequencies).
                 It should end with .P or .txt.
-                The file should use space (' ') as the delimiter.
+                The file should use space (' ') as the delimiter. If None, P is not loaded.
         """
         return self.__P_file
 
@@ -140,8 +140,11 @@ class AdmixtureReader(WideBaseReader):
         """
         log.info(f"Reading Q matrix from '{self.Q_file}'...")
         Q_mat = np.genfromtxt(self.Q_file, delimiter=' ')
-        log.info(f"Reading P matrix from '{self.P_file}'...")
-        P_mat = np.genfromtxt(self.P_file, delimiter=' ')
+        if self.P_file is not None:
+            log.info(f"Reading P matrix from '{self.P_file}'...")
+            P_mat = np.genfromtxt(self.P_file, delimiter=' ')
+        else:
+            P_mat = None
 
         samples = self._read_sample_ids()
         snps = self._read_snps()

--- a/snputils/ancestry/io/wide/read/base.py
+++ b/snputils/ancestry/io/wide/read/base.py
@@ -14,7 +14,7 @@ class WideBaseReader(abc.ABC):
     def __init__(
         self,
         Q_file: Union[str, Path],
-        P_file: Union[str, Path],
+        P_file: Optional[Union[str, Path]] = None,
         sample_file: Optional[Union[str, Path]] = None,
         snp_file: Optional[Union[str, Path]] = None,
         ancestry_file: Optional[Union[str, Path]] = None
@@ -25,10 +25,10 @@ class WideBaseReader(abc.ABC):
                 Path to the file containing the Q matrix (per-sample ancestry proportions).
                 It should end with `.Q` or `.txt`.
                 The file should use space (' ') as the delimiter.
-            P_file (str or pathlib.Path):
+            P_file (str or pathlib.Path, optional):
                 Path to the file containing the P/F matrix (per-ancestry SNP frequencies).
                 It should end with `.P` or `.txt`.
-                The file should use space (' ') as the delimiter.
+                The file should use space (' ') as the delimiter. If None, P is not loaded.
             sample_file (str or pathlib.Path, optional):
                 Path to the single-column file containing sample identifiers. 
                 It should end with `.fam` or `.txt`.
@@ -43,7 +43,7 @@ class WideBaseReader(abc.ABC):
                 If None, ancestries are not loaded.
         """
         self.__Q_file = Path(Q_file)
-        self.__P_file = Path(P_file)
+        self.__P_file = Path(P_file) if P_file is not None else None
         self.__sample_file = Path(sample_file) if sample_file is not None else None
         self.__snp_file = Path(snp_file) if snp_file is not None else None
         self.__ancestry_file = Path(ancestry_file) if ancestry_file is not None else None
@@ -62,15 +62,15 @@ class WideBaseReader(abc.ABC):
         return self.__Q_file
 
     @property
-    def P_file(self) -> Path:
+    def P_file(self) -> Optional[Path]:
         """
         Retrieve `P_file`.
 
         Returns:
-            **pathlib.Path:** 
+            **pathlib.Path or None:** 
                 Path to the file containing the P/F matrix (per-ancestry SNP frequencies).
                 It should end with `.P` or `.txt`.
-                The file should use space (' ') as the delimiter.
+                The file should use space (' ') as the delimiter. If None, P is not loaded.
         """
         return self.__P_file
 

--- a/snputils/ancestry/io/wide/read/functional.py
+++ b/snputils/ancestry/io/wide/read/functional.py
@@ -6,7 +6,7 @@ from snputils.ancestry.genobj.wide import GlobalAncestryObject
 
 def read_admixture(
     Q_file: Union[str, Path],
-    P_file: Union[str, Path],
+    P_file: Optional[Union[str, Path]] = None,
     sample_file: Optional[Union[str, Path]] = None,
     snp_file: Optional[Union[str, Path]] = None,
     ancestry_file: Optional[Union[str, Path]] = None,
@@ -19,10 +19,10 @@ def read_admixture(
             Path to the file containing the Q matrix (per-sample ancestry proportions).
             It should end with .Q or .txt.
             The file should use space (' ') as the delimiter.
-        P_file (str or pathlib.Path):
+        P_file (str or pathlib.Path, optional):
             Path to the file containing the P/F matrix (per-ancestry SNP frequencies).
             It should end with .P or .txt.
-            The file should use space (' ') as the delimiter.
+            The file should use space (' ') as the delimiter. If None, P is not loaded.
         sample_file (str or pathlib.Path, optional):
             Path to the single-column file containing sample identifiers. 
             It should end with .fam or .txt.

--- a/snputils/ancestry/io/wide/read/functional.py
+++ b/snputils/ancestry/io/wide/read/functional.py
@@ -45,7 +45,7 @@ def read_admixture(
     return AdmixtureReader(
         Q_file=Q_file,
         P_file=P_file,
-        sample_id_file=sample_file,
+        sample_file=sample_file,
         snp_file=snp_file,
         ancestry_file=ancestry_file
     ).read()

--- a/snputils/visualization/admixture.py
+++ b/snputils/visualization/admixture.py
@@ -30,26 +30,39 @@ def reorder_admixture(Q_mat):
     
     return Q_mat_sorted, row_order, boundary_list, col_order
 
-def plot_admixture(ax, Q_mat_sorted, boundary_list, col_order=None, colors=None):
+def plot_admixture(ax, Q_mat_sorted, boundary_list, col_order=None, colors=None, show_boundaries=True, show_axes_labels=True, show_ticks=True, set_limits=True, minimal=False):
     """
     Plot a structure-style bar chart of Q_mat_sorted in the given Axes ax.
     If colors is not None, it should be a list or array of length K.
     If col_order is not None, colors are reordered according to col_order.
+
+    Optional controls:
+    - show_boundaries (bool): draw vertical lines at group boundaries. Default True.
+    - show_axes_labels (bool): set X/Y axis labels. Default True.
+    - show_ticks (bool): show axis ticks. Default True.
+    - set_limits (bool): set xlim and ylim to [0, n_samples-1] and [0,1]. Default True.
+    - minimal (bool): if True, overrides to disable boundaries, labels, ticks, limits and hides spines.
     """
     n_samples, K = Q_mat_sorted.shape
-    
+
+    # Minimal overrides
+    if minimal:
+        show_boundaries = False
+        show_axes_labels = False
+        show_ticks = False
+        set_limits = False
+
     # If we have a specific color list and a col_order, reorder the colors to match the columns
     if (colors is not None) and (col_order is not None):
-        # re-map the user-provided colors to match the new column order
         colors = [colors[idx] for idx in col_order]
-    
+
     # cumulative sum across columns for stacked fill
     Q_cum = np.cumsum(Q_mat_sorted, axis=1)
     x_vals = np.arange(n_samples)
-    
+
     step_mode = "post"
     ax.step(x_vals, Q_cum, linewidth=0.0, where=step_mode)
-    
+
     # fill-between for a stacked bar effect
     for j in range(K):
         c = colors[j] if (colors is not None) else None
@@ -57,12 +70,25 @@ def plot_admixture(ax, Q_mat_sorted, boundary_list, col_order=None, colors=None)
             ax.fill_between(x_vals, 0, Q_cum[:, j], step=step_mode, color=c)
         else:
             ax.fill_between(x_vals, Q_cum[:, j - 1], Q_cum[:, j], step=step_mode, color=c)
-    
+
     # Vertical lines for group boundaries
-    for boundary in boundary_list:
-        ax.axvline(boundary, color='black', ls='--', lw=1.0)
-    
-    ax.set_xlim(0, n_samples - 1)
-    ax.set_ylim(0, 1)
-    ax.set_xlabel("Samples")
-    ax.set_ylabel("Ancestry Proportion")
+    if show_boundaries:
+        for boundary in boundary_list:
+            ax.axvline(boundary, color='black', ls='--', lw=1.0)
+
+    if set_limits:
+        ax.set_xlim(0, n_samples - 1)
+        ax.set_ylim(0, 1)
+
+    if show_axes_labels:
+        ax.set_xlabel("Samples")
+        ax.set_ylabel("Ancestry Proportion")
+
+    if not show_ticks:
+        ax.set_xticks([])
+        ax.set_yticks([])
+
+    if minimal:
+        # Hide all spines for a clean, minimal appearance
+        for spine in ax.spines.values():
+            spine.set_visible(False)


### PR DESCRIPTION
- Fix admixture plot boundary handling
- Fix some typos
- Make P optional for global ancestry. There is certain cases where you might want to analyze admixture proportions (e.g., do amixture plots, where P is not needed) and you only have admixture proportions (e.g., when you obtain admixture proportions from LAI).
- Make admixture plot more customizable