### PR TITLE
Add IBD analysis with support for hap-IBD and ancIBD 

### DIFF
--- a/snputils/__init__.py
+++ b/snputils/__init__.py
@@ -8,6 +8,7 @@ except PackageNotFoundError:
 
 from .snp import SNPObject, SNPReader, BEDReader, PGENReader, VCFReader, BEDWriter, PGENWriter, VCFWriter, read_snp, read_bed, read_pgen, read_vcf
 from .ancestry import LocalAncestryObject, GlobalAncestryObject, MSPReader, MSPWriter, AdmixtureMappingVCFWriter, AdmixtureReader, AdmixtureWriter, read_lai, read_msp, read_adm, read_admixture
+from .ibd import IBDObject, read_ibd, HapIBDReader, AncIBDReader, IBDReader
 from .phenotype import MultiPhenotypeObject, UKBPhenotypeObject, MultiPhenTabularReader, UKBPhenReader
 from . import visualization as viz
 from .datasets import load_dataset

--- a/snputils/ibd/__init__.py
+++ b/snputils/ibd/__init__.py
@@ -1,0 +1,6 @@
+from .genobj.ibdobj import IBDObject
+from .io import read_ibd, HapIBDReader, AncIBDReader, IBDReader
+
+__all__ = ['IBDObject', 'read_ibd', 'HapIBDReader', 'AncIBDReader', 'IBDReader']
+
+

--- a/snputils/ibd/genobj/__init__.py
+++ b/snputils/ibd/genobj/__init__.py
@@ -1,0 +1,5 @@
+from .ibdobj import IBDObject
+
+__all__ = ['IBDObject']
+
+

--- a/snputils/ibd/genobj/__test__/test_restrict_to_ancestry.py
+++ b/snputils/ibd/genobj/__test__/test_restrict_to_ancestry.py
@@ -1,0 +1,144 @@
+import numpy as np
+
+from snputils.ibd.genobj.ibdobj import IBDObject
+from snputils.ancestry.genobj.local import LocalAncestryObject
+
+
+def _make_lai_object():
+    # Three windows on chr1: [500-1500], [1501-2500], [2501-3500]
+    physical_pos = np.array([[500, 1500], [1501, 2500], [2501, 3500]], dtype=int)
+    chromosomes = np.array(["1", "1", "1"], dtype=object)
+    # Simple cM map: 0.0-0.1, 0.1-0.4, 0.4-0.6
+    centimorgan_pos = np.array([[0.0, 0.1], [0.1, 0.4], [0.4, 0.6]], dtype=float)
+    haplotypes = ["A.0", "A.1", "B.0", "B.1"]
+    # Initialize with zeros (ancestry 0)
+    lai = np.zeros((3, 4), dtype=int)
+    return physical_pos, chromosomes, centimorgan_pos, haplotypes, lai
+
+
+def test_restrict_to_ancestry_hap_known_and_cm():
+    physical_pos, chromosomes, centimorgan_pos, haplotypes, lai = _make_lai_object()
+
+    # Set ancestry=1 for A.0 and B.1 in the middle window only
+    lai[1, :] = [1, 0, 0, 1]
+
+    laiobj = LocalAncestryObject(
+        haplotypes=haplotypes,
+        lai=lai,
+        samples=["A", "B"],
+        ancestry_map=None,
+        window_sizes=np.array([1, 1, 1]),
+        centimorgan_pos=centimorgan_pos,
+        chromosomes=chromosomes,
+        physical_pos=physical_pos,
+    )
+
+    # IBD segment covers all three windows; haplotypes are known: A hap1 (.0), B hap2 (.1)
+    ibd = IBDObject(
+        sample_id_1=np.array(["A"], dtype=object),
+        haplotype_id_1=np.array([1], dtype=int),
+        sample_id_2=np.array(["B"], dtype=object),
+        haplotype_id_2=np.array([2], dtype=int),
+        chrom=np.array(["1"], dtype=object),
+        start=np.array([1000], dtype=int),
+        end=np.array([3000], dtype=int),
+        length_cm=np.array([5.0], dtype=float),
+        segment_type=np.array(["IBD1"], dtype=object),
+    )
+
+    # Restrict to ancestry 1; expect one trimmed subsegment [1501, 2500] with cM ~= 0.3
+    out = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1)
+    assert out is not None
+    assert out.n_segments == 1
+    assert out.start.tolist() == [1501]
+    assert out.end.tolist() == [2500]
+    assert out.chrom.tolist() == ["1"]
+    assert out.sample_id_1.tolist() == ["A"]
+    assert out.sample_id_2.tolist() == ["B"]
+    # cM from middle window (0.1 -> 0.4)
+    assert np.isclose(out.length_cm[0], 0.3, rtol=0, atol=1e-9)
+
+    # If requiring both haps to match, nothing should remain because A.1 and B.0 are 0 in that window
+    out2 = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, require_both_haplotypes=True)
+    assert out2 is not None
+    assert out2.n_segments == 0
+
+
+def test_restrict_to_ancestry_unknown_haps_any_vs_both():
+    physical_pos, chromosomes, centimorgan_pos, haplotypes, lai = _make_lai_object()
+    # In the middle window, A.0 = 1, B.1 = 1; other haps 0
+    lai[1, :] = [1, 0, 0, 1]
+
+    laiobj = LocalAncestryObject(
+        haplotypes=haplotypes,
+        lai=lai,
+        samples=["A", "B"],
+        ancestry_map=None,
+        window_sizes=np.array([1, 1, 1]),
+        centimorgan_pos=centimorgan_pos,
+        chromosomes=chromosomes,
+        physical_pos=physical_pos,
+    )
+
+    # IBD segment with unknown hap IDs (ancIBD-like)
+    ibd = IBDObject(
+        sample_id_1=np.array(["A"], dtype=object),
+        haplotype_id_1=np.array([-1], dtype=int),
+        sample_id_2=np.array(["B"], dtype=object),
+        haplotype_id_2=np.array([-1], dtype=int),
+        chrom=np.array(["1"], dtype=object),
+        start=np.array([1000], dtype=int),
+        end=np.array([3000], dtype=int),
+        length_cm=np.array([5.0], dtype=float),
+        segment_type=np.array(["IBD1"], dtype=object),
+    )
+
+    out_any = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, require_both_haplotypes=False)
+    assert out_any.n_segments == 1
+    assert out_any.start.tolist() == [1501]
+    assert out_any.end.tolist() == [2500]
+
+    out_both = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, require_both_haplotypes=True)
+    # A.1 and B.0 are 0, so requiring both per individual should drop it
+    assert out_both.n_segments == 0
+
+
+def test_restrict_to_ancestry_cm_fallback_scaling():
+    # Same windows but without cM map; length should scale from original by bp fraction
+    physical_pos = np.array([[500, 1500], [1501, 2500], [2501, 3500]], dtype=int)
+    chromosomes = np.array(["1", "1", "1"], dtype=object)
+    haplotypes = ["A.0", "A.1", "B.0", "B.1"]
+    lai = np.zeros((3, 4), dtype=int)
+    lai[1, :] = [1, 0, 0, 1]
+
+    laiobj = LocalAncestryObject(
+        haplotypes=haplotypes,
+        lai=lai,
+        samples=["A", "B"],
+        ancestry_map=None,
+        window_sizes=np.array([1, 1, 1]),
+        centimorgan_pos=None,
+        chromosomes=chromosomes,
+        physical_pos=physical_pos,
+    )
+
+    # IBD covers 1000-3000 (length=2001 bp). The kept window is ~1000 bp.
+    # If original cM is 6.0, expect ~3.0 cM after restricting.
+    ibd = IBDObject(
+        sample_id_1=np.array(["A"], dtype=object),
+        haplotype_id_1=np.array([1], dtype=int),
+        sample_id_2=np.array(["B"], dtype=object),
+        haplotype_id_2=np.array([2], dtype=int),
+        chrom=np.array(["1"], dtype=object),
+        start=np.array([1000], dtype=int),
+        end=np.array([3000], dtype=int),
+        length_cm=np.array([6.0], dtype=float),
+        segment_type=np.array(["IBD1"], dtype=object),
+    )
+
+    out = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1)
+    assert out.n_segments == 1
+    # Approx half of original cM
+    assert np.isclose(out.length_cm[0], 3.0, rtol=0.05, atol=0.15)
+
+

--- a/snputils/ibd/genobj/__test__/test_restrict_to_ancestry.py
+++ b/snputils/ibd/genobj/__test__/test_restrict_to_ancestry.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from snputils.ibd.genobj.ibdobj import IBDObject
 from snputils.ancestry.genobj.local import LocalAncestryObject
@@ -142,3 +143,248 @@ def test_restrict_to_ancestry_cm_fallback_scaling():
     assert np.isclose(out.length_cm[0], 3.0, rtol=0.05, atol=0.15)
 
 
+def test_restrict_to_ancestry_strict_mode_drop_segment():
+    physical_pos, chromosomes, centimorgan_pos, haplotypes, lai = _make_lai_object()
+
+    # Set ancestry=1 for A.0 and B.1 in the middle window only
+    lai[1, :] = [1, 0, 0, 1]
+
+    laiobj = LocalAncestryObject(
+        haplotypes=haplotypes,
+        lai=lai,
+        samples=["A", "B"],
+        ancestry_map=None,
+        window_sizes=np.array([1, 1, 1]),
+        centimorgan_pos=centimorgan_pos,
+        chromosomes=chromosomes,
+        physical_pos=physical_pos,
+    )
+
+    # IBD segment covers all three windows; haplotypes are known: A hap1 (.0), B hap2 (.1)
+    ibd = IBDObject(
+        sample_id_1=np.array(["A"], dtype=object),
+        haplotype_id_1=np.array([1], dtype=int),
+        sample_id_2=np.array(["B"], dtype=object),
+        haplotype_id_2=np.array([2], dtype=int),
+        chrom=np.array(["1"], dtype=object),
+        start=np.array([1000], dtype=int),
+        end=np.array([3000], dtype=int),
+        length_cm=np.array([5.0], dtype=float),
+        segment_type=np.array(["IBD1"], dtype=object),
+    )
+
+    # Strict mode should drop entire segment because first and third windows lack target ancestry
+    out_strict = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='strict')
+    assert out_strict is not None
+    assert out_strict.n_segments == 0
+
+    # Clip mode should return trimmed segment for comparison
+    out_clip = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='clip')
+    assert out_clip is not None
+    assert out_clip.n_segments == 1
+    assert out_clip.start.tolist() == [1501]
+    assert out_clip.end.tolist() == [2500]
+
+
+def test_restrict_to_ancestry_strict_mode_keep_segment():
+    physical_pos, chromosomes, centimorgan_pos, haplotypes, lai = _make_lai_object()
+
+    # Set ancestry=1 for A.0 and B.1 in ALL windows
+    lai[:, :] = [[1, 0, 0, 1], [1, 0, 0, 1], [1, 0, 0, 1]]
+
+    laiobj = LocalAncestryObject(
+        haplotypes=haplotypes,
+        lai=lai,
+        samples=["A", "B"],
+        ancestry_map=None,
+        window_sizes=np.array([1, 1, 1]),
+        centimorgan_pos=centimorgan_pos,
+        chromosomes=chromosomes,
+        physical_pos=physical_pos,
+    )
+
+    # IBD segment covers all three windows
+    ibd = IBDObject(
+        sample_id_1=np.array(["A"], dtype=object),
+        haplotype_id_1=np.array([1], dtype=int),
+        sample_id_2=np.array(["B"], dtype=object),
+        haplotype_id_2=np.array([2], dtype=int),
+        chrom=np.array(["1"], dtype=object),
+        start=np.array([1000], dtype=int),
+        end=np.array([3000], dtype=int),
+        length_cm=np.array([5.0], dtype=float),
+        segment_type=np.array(["IBD1"], dtype=object),
+    )
+
+    # Strict mode should keep entire segment with original coordinates
+    out_strict = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='strict')
+    assert out_strict is not None
+    assert out_strict.n_segments == 1
+    assert out_strict.start.tolist() == [1000]
+    assert out_strict.end.tolist() == [3000]
+    assert out_strict.length_cm.tolist() == [5.0]
+    assert out_strict.sample_id_1.tolist() == ["A"]
+    assert out_strict.sample_id_2.tolist() == ["B"]
+
+
+def test_restrict_to_ancestry_strict_vs_clip_partial_overlap():
+    physical_pos, chromosomes, centimorgan_pos, haplotypes, lai = _make_lai_object()
+
+    # Set ancestry=1 for A.0 and B.1 in first window only
+    lai[0, :] = [1, 0, 0, 1]
+
+    laiobj = LocalAncestryObject(
+        haplotypes=haplotypes,
+        lai=lai,
+        samples=["A", "B"],
+        ancestry_map=None,
+        window_sizes=np.array([1, 1, 1]),
+        centimorgan_pos=centimorgan_pos,
+        chromosomes=chromosomes,
+        physical_pos=physical_pos,
+    )
+
+    # IBD segment overlaps first two windows only
+    ibd = IBDObject(
+        sample_id_1=np.array(["A"], dtype=object),
+        haplotype_id_1=np.array([1], dtype=int),
+        sample_id_2=np.array(["B"], dtype=object),
+        haplotype_id_2=np.array([2], dtype=int),
+        chrom=np.array(["1"], dtype=object),
+        start=np.array([1000], dtype=int),
+        end=np.array([2000], dtype=int),
+        length_cm=np.array([3.0], dtype=float),
+        segment_type=np.array(["IBD1"], dtype=object),
+    )
+
+    # Strict mode should drop segment because second window lacks target ancestry
+    out_strict = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='strict')
+    assert out_strict is not None
+    assert out_strict.n_segments == 0
+
+    # Clip mode should trim to first window portion
+    out_clip = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='clip')
+    assert out_clip is not None
+    assert out_clip.n_segments == 1
+    assert out_clip.start.tolist() == [1000]
+    assert out_clip.end.tolist() == [1500]
+
+
+def test_restrict_to_ancestry_strict_unknown_haplotypes():
+    physical_pos, chromosomes, centimorgan_pos, haplotypes, lai = _make_lai_object()
+
+    # Mixed pattern: first window has A.0=1, B.1=1; second has A.1=1, B.0=1; third has none
+    lai[0, :] = [1, 0, 0, 1]
+    lai[1, :] = [0, 1, 1, 0]
+
+    laiobj = LocalAncestryObject(
+        haplotypes=haplotypes,
+        lai=lai,
+        samples=["A", "B"],
+        ancestry_map=None,
+        window_sizes=np.array([1, 1, 1]),
+        centimorgan_pos=centimorgan_pos,
+        chromosomes=chromosomes,
+        physical_pos=physical_pos,
+    )
+
+    # IBD segment with unknown haplotype IDs
+    ibd = IBDObject(
+        sample_id_1=np.array(["A"], dtype=object),
+        haplotype_id_1=np.array([-1], dtype=int),
+        sample_id_2=np.array(["B"], dtype=object),
+        haplotype_id_2=np.array([-1], dtype=int),
+        chrom=np.array(["1"], dtype=object),
+        start=np.array([1000], dtype=int),
+        end=np.array([3000], dtype=int),
+        length_cm=np.array([5.0], dtype=float),
+        segment_type=np.array(["IBD1"], dtype=object),
+    )
+
+    # With require_both_haplotypes=False, at least one hap must match per individual
+    # This should fail strict mode because third window has no matches
+    out_any = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='strict', require_both_haplotypes=False)
+    assert out_any is not None
+    assert out_any.n_segments == 0
+
+    # With require_both_haplotypes=True, should also fail because no window has both haps matching for both individuals
+    out_both = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='strict', require_both_haplotypes=True)
+    assert out_both is not None
+    assert out_both.n_segments == 0
+
+
+def test_restrict_to_ancestry_strict_length_filters():
+    physical_pos, chromosomes, centimorgan_pos, haplotypes, lai = _make_lai_object()
+
+    # Set ancestry=1 for A.0 and B.1 in ALL windows
+    lai[:, :] = [[1, 0, 0, 1], [1, 0, 0, 1], [1, 0, 0, 1]]
+
+    laiobj = LocalAncestryObject(
+        haplotypes=haplotypes,
+        lai=lai,
+        samples=["A", "B"],
+        ancestry_map=None,
+        window_sizes=np.array([1, 1, 1]),
+        centimorgan_pos=centimorgan_pos,
+        chromosomes=chromosomes,
+        physical_pos=physical_pos,
+    )
+
+    # Short IBD segment (101 bp, 0.05 cM)
+    ibd = IBDObject(
+        sample_id_1=np.array(["A"], dtype=object),
+        haplotype_id_1=np.array([1], dtype=int),
+        sample_id_2=np.array(["B"], dtype=object),
+        haplotype_id_2=np.array([2], dtype=int),
+        chrom=np.array(["1"], dtype=object),
+        start=np.array([1000], dtype=int),
+        end=np.array([1100], dtype=int),
+        length_cm=np.array([0.05], dtype=float),
+        segment_type=np.array(["IBD1"], dtype=object),
+    )
+
+    # No filters: should keep segment
+    out_no_filter = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='strict')
+    assert out_no_filter is not None
+    assert out_no_filter.n_segments == 1
+
+    # With min_bp=500: should drop segment (101 < 500)
+    out_bp_filter = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='strict', min_bp=500)
+    assert out_bp_filter is not None
+    assert out_bp_filter.n_segments == 0
+
+    # With min_cm=0.1: should drop segment (0.05 < 0.1)
+    out_cm_filter = ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='strict', min_cm=0.1)
+    assert out_cm_filter is not None
+    assert out_cm_filter.n_segments == 0
+
+
+def test_restrict_to_ancestry_method_validation():
+    physical_pos, chromosomes, centimorgan_pos, haplotypes, lai = _make_lai_object()
+
+    laiobj = LocalAncestryObject(
+        haplotypes=haplotypes,
+        lai=lai,
+        samples=["A", "B"],
+        ancestry_map=None,
+        window_sizes=np.array([1, 1, 1]),
+        centimorgan_pos=centimorgan_pos,
+        chromosomes=chromosomes,
+        physical_pos=physical_pos,
+    )
+
+    ibd = IBDObject(
+        sample_id_1=np.array(["A"], dtype=object),
+        haplotype_id_1=np.array([1], dtype=int),
+        sample_id_2=np.array(["B"], dtype=object),
+        haplotype_id_2=np.array([2], dtype=int),
+        chrom=np.array(["1"], dtype=object),
+        start=np.array([1000], dtype=int),
+        end=np.array([3000], dtype=int),
+        length_cm=np.array([5.0], dtype=float),
+        segment_type=np.array(["IBD1"], dtype=object),
+    )
+
+    # Invalid method should raise ValueError
+    with pytest.raises(ValueError, match="Method must be 'strict' or 'clip', got 'invalid'"):
+        ibd.restrict_to_ancestry(laiobj=laiobj, ancestry=1, method='invalid')

--- a/snputils/ibd/genobj/ibdobj.py
+++ b/snputils/ibd/genobj/ibdobj.py
@@ -28,9 +28,9 @@ class IBDObject:
         """
         Args:
             sample_id_1 (array of shape (n_segments,)): Sample identifiers for the first individual.
-            haplotype_id_1 (array of shape (n_segments,)): Haplotype identifiers for the first individual (values in {1, 2}).
+            haplotype_id_1 (array of shape (n_segments,)): Haplotype identifiers for the first individual (values in {1, 2}, or -1 if unknown).
             sample_id_2 (array of shape (n_segments,)): Sample identifiers for the second individual.
-            haplotype_id_2 (array of shape (n_segments,)): Haplotype identifiers for the second individual (values in {1, 2}).
+            haplotype_id_2 (array of shape (n_segments,)): Haplotype identifiers for the second individual (values in {1, 2}, or -1 if unknown).
             chrom (array of shape (n_segments,)): Chromosome identifier for each IBD segment.
             start (array of shape (n_segments,)): Start physical position (1-based, bp) for each IBD segment.
             end (array of shape (n_segments,)): End physical position (1-based, bp) for each IBD segment.

--- a/snputils/ibd/genobj/ibdobj.py
+++ b/snputils/ibd/genobj/ibdobj.py
@@ -1,0 +1,640 @@
+import logging
+import copy
+from typing import Any, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+
+log = logging.getLogger(__name__)
+
+
+class IBDObject:
+    """
+    A class for Identity-By-Descent (IBD) segment data.
+    """
+
+    def __init__(
+        self,
+        sample_id_1: np.ndarray,
+        haplotype_id_1: np.ndarray,
+        sample_id_2: np.ndarray,
+        haplotype_id_2: np.ndarray,
+        chrom: np.ndarray,
+        start: np.ndarray,
+        end: np.ndarray,
+        length_cm: Optional[np.ndarray] = None,
+        segment_type: Optional[np.ndarray] = None,
+    ) -> None:
+        """
+        Args:
+            sample_id_1 (array of shape (n_segments,)): Sample identifiers for the first individual.
+            haplotype_id_1 (array of shape (n_segments,)): Haplotype identifiers for the first individual (values in {1, 2}).
+            sample_id_2 (array of shape (n_segments,)): Sample identifiers for the second individual.
+            haplotype_id_2 (array of shape (n_segments,)): Haplotype identifiers for the second individual (values in {1, 2}).
+            chrom (array of shape (n_segments,)): Chromosome identifier for each IBD segment.
+            start (array of shape (n_segments,)): Start physical position (1-based, bp) for each IBD segment.
+            end (array of shape (n_segments,)): End physical position (1-based, bp) for each IBD segment.
+            length_cm (array of shape (n_segments,), optional): Genetic length (cM) for each segment, if available.
+        """
+        # Store attributes
+        self.__sample_id_1 = np.asarray(sample_id_1)
+        self.__haplotype_id_1 = np.asarray(haplotype_id_1)
+        self.__sample_id_2 = np.asarray(sample_id_2)
+        self.__haplotype_id_2 = np.asarray(haplotype_id_2)
+        self.__chrom = np.asarray(chrom)
+        self.__start = np.asarray(start)
+        self.__end = np.asarray(end)
+        self.__length_cm = None if length_cm is None else np.asarray(length_cm)
+        self.__segment_type = None if segment_type is None else np.asarray(segment_type)
+
+        self._sanity_check()
+
+    def __getitem__(self, key: str) -> Any:
+        """
+        To access an attribute of the class using the square bracket notation,
+        similar to a dictionary.
+        """
+        try:
+            return getattr(self, key)
+        except Exception:
+            raise KeyError(f"Invalid key: {key}.")
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """
+        To set an attribute of the class using the square bracket notation,
+        similar to a dictionary.
+        """
+        try:
+            setattr(self, key, value)
+        except Exception:
+            raise KeyError(f"Invalid key: {key}.")
+
+    @property
+    def sample_id_1(self) -> np.ndarray:
+        """
+        Retrieve `sample_id_1`.
+
+        Returns:
+            **array of shape (n_segments,):** Sample identifiers for the first individual.
+        """
+        return self.__sample_id_1
+
+    @sample_id_1.setter
+    def sample_id_1(self, x: Sequence) -> None:
+        """
+        Update `sample_id_1`.
+        """
+        self.__sample_id_1 = np.asarray(x)
+
+    @property
+    def haplotype_id_1(self) -> np.ndarray:
+        """
+        Retrieve `haplotype_id_1`.
+
+        Returns:
+            **array of shape (n_segments,):** Haplotype identifiers for the first individual (values in {1, 2}).
+        """
+        return self.__haplotype_id_1
+
+    @haplotype_id_1.setter
+    def haplotype_id_1(self, x: Sequence) -> None:
+        """
+        Update `haplotype_id_1`.
+        """
+        self.__haplotype_id_1 = np.asarray(x)
+
+    @property
+    def sample_id_2(self) -> np.ndarray:
+        """
+        Retrieve `sample_id_2`.
+
+        Returns:
+            **array of shape (n_segments,):** Sample identifiers for the second individual.
+        """
+        return self.__sample_id_2
+
+    @sample_id_2.setter
+    def sample_id_2(self, x: Sequence) -> None:
+        """
+        Update `sample_id_2`.
+        """
+        self.__sample_id_2 = np.asarray(x)
+
+    @property
+    def haplotype_id_2(self) -> np.ndarray:
+        """
+        Retrieve `haplotype_id_2`.
+
+        Returns:
+            **array of shape (n_segments,):** Haplotype identifiers for the second individual (values in {1, 2}).
+        """
+        return self.__haplotype_id_2
+
+    @haplotype_id_2.setter
+    def haplotype_id_2(self, x: Sequence) -> None:
+        """
+        Update `haplotype_id_2`.
+        """
+        self.__haplotype_id_2 = np.asarray(x)
+
+    @property
+    def chrom(self) -> np.ndarray:
+        """
+        Retrieve `chrom`.
+
+        Returns:
+            **array of shape (n_segments,):** Chromosome identifier for each IBD segment.
+        """
+        return self.__chrom
+
+    @chrom.setter
+    def chrom(self, x: Sequence) -> None:
+        """
+        Update `chrom`.
+        """
+        self.__chrom = np.asarray(x)
+
+    @property
+    def start(self) -> np.ndarray:
+        """
+        Retrieve `start`.
+
+        Returns:
+            **array of shape (n_segments,):** Start physical position (1-based, bp) for each IBD segment.
+        """
+        return self.__start
+
+    @start.setter
+    def start(self, x: Sequence) -> None:
+        """
+        Update `start`.
+        """
+        self.__start = np.asarray(x)
+
+    @property
+    def end(self) -> np.ndarray:
+        """
+        Retrieve `end`.
+
+        Returns:
+            **array of shape (n_segments,):** End physical position (1-based, bp) for each IBD segment.
+        """
+        return self.__end
+
+    @end.setter
+    def end(self, x: Sequence) -> None:
+        """
+        Update `end`.
+        """
+        self.__end = np.asarray(x)
+
+    @property
+    def length_cm(self) -> Optional[np.ndarray]:
+        """
+        Retrieve `length_cm`.
+
+        Returns:
+            **array of shape (n_segments,):** Genetic length (cM) for each segment if available; otherwise None.
+        """
+        return self.__length_cm
+
+    @length_cm.setter
+    def length_cm(self, x: Optional[Sequence]) -> None:
+        """
+        Update `length_cm`.
+        """
+        self.__length_cm = None if x is None else np.asarray(x)
+
+    @property
+    def segment_type(self) -> Optional[np.ndarray]:
+        """
+        Retrieve `segment_type`.
+
+        Returns:
+            **array of shape (n_segments,):** Segment type labels (e.g., 'IBD1', 'IBD2'), or None if unavailable.
+        """
+        return self.__segment_type
+
+    @segment_type.setter
+    def segment_type(self, x: Optional[Sequence]) -> None:
+        """
+        Update `segment_type`.
+        """
+        self.__segment_type = None if x is None else np.asarray(x)
+
+    @property
+    def n_segments(self) -> int:
+        """
+        Retrieve `n_segments`.
+
+        Returns:
+            **int:** The total number of IBD segments.
+        """
+        return self.__chrom.shape[0]
+
+    @property
+    def pairs(self) -> np.ndarray:
+        """
+        Retrieve `pairs`.
+
+        Returns:
+            **array of shape (n_segments, 2):** Per-segment sample identifier pairs.
+        """
+        return np.column_stack([self.__sample_id_1, self.__sample_id_2])
+
+    @property
+    def haplotype_pairs(self) -> np.ndarray:
+        """
+        Retrieve `haplotype_pairs`.
+
+        Returns:
+            **array of shape (n_segments, 2):** Per-segment haplotype identifier pairs.
+        """
+        return np.column_stack([self.__haplotype_id_1, self.__haplotype_id_2])
+
+    def copy(self) -> 'IBDObject':
+        """
+        Create and return a copy of `self`.
+
+        Returns:
+            **IBDObject:** A new instance of the current object.
+        """
+        return copy.deepcopy(self)
+
+    def keys(self) -> List[str]:
+        """
+        Retrieve a list of public attribute names for `self`.
+
+        Returns:
+            **list of str:** A list of attribute names, with internal name-mangling removed.
+        """
+        return [attr.replace('_IBDObject__', '') for attr in vars(self)]
+
+    def filter_segments(
+        self,
+        chrom: Optional[Sequence[str]] = None,
+        samples: Optional[Sequence[str]] = None,
+        min_length_cm: Optional[float] = None,
+        segment_types: Optional[Sequence[str]] = None,
+        inplace: bool = False,
+    ) -> Optional['IBDObject']:
+        """
+        Filter IBD segments by chromosome, sample names, and/or minimum genetic length.
+
+        Args:
+            chrom (sequence of str, optional): Chromosome(s) to include.
+            samples (sequence of str, optional): Sample names to include if present in either column.
+            min_length_cm (float, optional): Minimum cM length threshold.
+            inplace (bool, default=False): If True, modifies `self` in place. If False, returns a new `IBDObject`.
+
+        Returns:
+            **Optional[IBDObject]:** A filtered IBDObject if `inplace=False`. If `inplace=True`, returns None.
+        """
+        mask = np.ones(self.n_segments, dtype=bool)
+
+        if chrom is not None:
+            chrom = np.atleast_1d(chrom)
+            mask &= np.isin(self.__chrom, chrom)
+
+        if samples is not None:
+            samples = np.atleast_1d(samples)
+            mask &= np.isin(self.__sample_id_1, samples) | np.isin(self.__sample_id_2, samples)
+
+        if min_length_cm is not None and self.__length_cm is not None:
+            mask &= self.__length_cm >= float(min_length_cm)
+
+        if segment_types is not None and self.__segment_type is not None:
+            segment_types = np.atleast_1d(segment_types)
+            mask &= np.isin(self.__segment_type, segment_types)
+
+        def _apply_mask(x: Optional[np.ndarray]) -> Optional[np.ndarray]:
+            return None if x is None else np.asarray(x)[mask]
+
+        if inplace:
+            self.__sample_id_1 = _apply_mask(self.__sample_id_1)
+            self.__haplotype_id_1 = _apply_mask(self.__haplotype_id_1)
+            self.__sample_id_2 = _apply_mask(self.__sample_id_2)
+            self.__haplotype_id_2 = _apply_mask(self.__haplotype_id_2)
+            self.__chrom = _apply_mask(self.__chrom)
+            self.__start = _apply_mask(self.__start)
+            self.__end = _apply_mask(self.__end)
+            self.__length_cm = _apply_mask(self.__length_cm)
+            self.__segment_type = _apply_mask(self.__segment_type)
+            return None
+        else:
+            return IBDObject(
+                sample_id_1=_apply_mask(self.__sample_id_1),
+                haplotype_id_1=_apply_mask(self.__haplotype_id_1),
+                sample_id_2=_apply_mask(self.__sample_id_2),
+                haplotype_id_2=_apply_mask(self.__haplotype_id_2),
+                chrom=_apply_mask(self.__chrom),
+                start=_apply_mask(self.__start),
+                end=_apply_mask(self.__end),
+                length_cm=_apply_mask(self.__length_cm),
+                segment_type=_apply_mask(self.__segment_type),
+            )
+
+    def restrict_to_ancestry(
+        self,
+        *,
+        laiobj: Any,
+        ancestry: Any,
+        require_both_haplotypes: bool = False,
+        min_bp: Optional[int] = None,
+        min_cm: Optional[float] = None,
+        inplace: bool = False,
+    ) -> Optional['IBDObject']:
+        """
+        Trim IBD segments to intervals where both individuals carry the specified ancestry
+        according to a `LocalAncestryObject`.
+
+        This performs an interval intersection per segment against ancestry tracts:
+        - If haplotype IDs are known (e.g., Hap-IBD), ancestry is checked on the specific
+          haplotype of each individual.
+        - If haplotype IDs are unknown (e.g., ancIBD; haplotype_id_* == -1), ancestry is
+          considered present for an individual if at least one of their haplotypes matches
+          the requested ancestry (unless `require_both_haplotypes=True`).
+
+        Resulting subsegments are clipped to LAI window boundaries and original IBD start/end,
+        with optional length filtering by bp or cM. If `laiobj.centimorgan_pos` is available,
+        genetic lengths are approximated by distributing window cM length proportionally to
+        base-pair overlap; otherwise, length is scaled from the original segment by bp fraction
+        when available, or set to None.
+
+        Args:
+            laiobj: LocalAncestryObject containing 2D `lai` of shape (n_windows, n_haplotypes),
+                `physical_pos` (n_windows, 2), and `chromosomes` (n_windows,).
+            ancestry: Target ancestry code or label. Compared as string, so both int and str work.
+            require_both_haplotypes: If True, require both haplotypes of each individual to have
+                the target ancestry within a window. When haplotypes are known per segment, this
+                only affects cases with unknown haplotypes (== -1) or IBD2 segments.
+            min_bp: Minimum base-pair length to retain a trimmed subsegment.
+            min_cm: Minimum centiMorgan length to retain a trimmed subsegment (applied after bp).
+            inplace: If True, replace `self` with the restricted object; else return a new object.
+
+        Returns:
+            Optional[IBDObject]: A restricted IBDObject if `inplace=False`. If `inplace=True`,
+                returns None.
+        """
+        # Basic LAI shape/metadata checks
+        lai = getattr(laiobj, 'lai', None)
+        physical_pos = getattr(laiobj, 'physical_pos', None)
+        chromosomes = getattr(laiobj, 'chromosomes', None)
+        centimorgan_pos = getattr(laiobj, 'centimorgan_pos', None)
+        haplotypes = getattr(laiobj, 'haplotypes', None)
+
+        if lai is None or physical_pos is None or chromosomes is None or haplotypes is None:
+            raise ValueError(
+                "`laiobj` must provide `lai`, `physical_pos`, `chromosomes`, and `haplotypes`."
+            )
+
+        if lai.ndim != 2:
+            raise ValueError("`laiobj.lai` must be 2D with shape (n_windows, n_haplotypes).")
+
+        # Build haplotype label -> column index map (labels like 'Sample.0', 'Sample.1')
+        hap_to_col = {str(h): i for i, h in enumerate(haplotypes)}
+
+        # Coerce ancestry to str for robust comparisons
+        anc_str = str(ancestry)
+
+        # Coerce LAI values to str once for comparisons
+        lai_str = lai.astype(str)
+
+        # Prepare arrays for the restricted segments
+        out_sample_id_1: List[str] = []
+        out_haplotype_id_1: List[int] = []
+        out_sample_id_2: List[str] = []
+        out_haplotype_id_2: List[int] = []
+        out_chrom: List[str] = []
+        out_start: List[int] = []
+        out_end: List[int] = []
+        out_length_cm: List[float] = []
+        out_segment_type: List[str] = [] if self.__segment_type is not None else None  # type: ignore
+
+        # Vectorize chrom compare by making LAI chromosome strings
+        chr_lai = np.asarray(chromosomes).astype(str)
+
+        # Helper to compute cM length for a trimmed interval using LAI windows
+        def _approx_cm_len(chr_mask: np.ndarray, start_bp: int, end_bp: int) -> Optional[float]:
+            if centimorgan_pos is None:
+                return None
+            win_st = physical_pos[chr_mask, 0]
+            win_en = physical_pos[chr_mask, 1]
+            win_cm_st = centimorgan_pos[chr_mask, 0]
+            win_cm_en = centimorgan_pos[chr_mask, 1]
+            cm_total = 0.0
+            for ws, we, cs, ce in zip(win_st, win_en, win_cm_st, win_cm_en):
+                # Overlap with [start_bp, end_bp]
+                overlap_start = max(int(ws), int(start_bp))
+                overlap_end = min(int(we), int(end_bp))
+                if overlap_start > overlap_end:
+                    continue
+                wlen_bp = max(1, int(we) - int(ws) + 1)
+                olen_bp = int(overlap_end) - int(overlap_start) + 1
+                frac = float(olen_bp) / float(wlen_bp)
+                cm_total += frac * float(ce - cs)
+            return cm_total
+
+        # Iterate over segments
+        for i in range(self.n_segments):
+            chrom = str(self.__chrom[i])
+            seg_start = int(self.__start[i])
+            seg_end = int(self.__end[i])
+            if seg_end < seg_start:
+                continue
+
+            # Subset LAI windows on this chromosome that overlap the segment
+            idx_chr = (chr_lai == chrom)
+            if not np.any(idx_chr):
+                continue
+            lai_st = physical_pos[idx_chr, 0]
+            lai_en = physical_pos[idx_chr, 1]
+            overlaps = (lai_en >= seg_start) & (lai_st <= seg_end)
+            if not np.any(overlaps):
+                continue
+
+            # Build per-window ancestry mask for both individuals
+            s1 = str(self.__sample_id_1[i])
+            s2 = str(self.__sample_id_2[i])
+            h1 = int(self.__haplotype_id_1[i]) if self.__haplotype_id_1 is not None else -1
+            h2 = int(self.__haplotype_id_2[i]) if self.__haplotype_id_2 is not None else -1
+
+            # Resolve haplotype column indices for each sample
+            # Known haplotypes are 1-based in inputs; convert to {0,1}
+            def _get_cols(sample: str) -> Tuple[int, int]:
+                a = hap_to_col.get(f"{sample}.0")
+                b = hap_to_col.get(f"{sample}.1")
+                if a is None or b is None:
+                    raise ValueError(f"Sample '{sample}' not found in LAI haplotypes.")
+                return a, b
+
+            s1_a, s1_b = _get_cols(s1)
+            s2_a, s2_b = _get_cols(s2)
+
+            # LAI rows for this chromosome
+            lai_rows = lai_str[idx_chr, :]
+
+            # Determine ancestry presence per window for each individual
+            if h1 in (1, 2) and h2 in (1, 2):
+                # Use specific haplotypes
+                s1_col = s1_a if (h1 - 1) == 0 else s1_b
+                s2_col = s2_a if (h2 - 1) == 0 else s2_b
+                s1_mask = (lai_rows[:, s1_col] == anc_str)
+                s2_mask = (lai_rows[:, s2_col] == anc_str)
+                if require_both_haplotypes:
+                    # Additionally require the other hap of each sample to match
+                    s1_other = s1_b if s1_col == s1_a else s1_a
+                    s2_other = s2_b if s2_col == s2_a else s2_a
+                    s1_mask = s1_mask & (lai_rows[:, s1_other] == anc_str)
+                    s2_mask = s2_mask & (lai_rows[:, s2_other] == anc_str)
+            else:
+                # Unknown hap IDs: require at least one hap to match (or both if requested)
+                if require_both_haplotypes:
+                    s1_mask = (lai_rows[:, s1_a] == anc_str) & (lai_rows[:, s1_b] == anc_str)
+                    s2_mask = (lai_rows[:, s2_a] == anc_str) & (lai_rows[:, s2_b] == anc_str)
+                else:
+                    s1_mask = (lai_rows[:, s1_a] == anc_str) | (lai_rows[:, s1_b] == anc_str)
+                    s2_mask = (lai_rows[:, s2_a] == anc_str) | (lai_rows[:, s2_b] == anc_str)
+
+            keep = overlaps & s1_mask & s2_mask
+            if not np.any(keep):
+                continue
+
+            # Identify contiguous windows where keep=True
+            idx_keep = np.where(keep)[0]
+            # Split into runs of consecutive indices
+            breaks = np.where(np.diff(idx_keep) > 1)[0]
+            run_starts = np.r_[0, breaks + 1]
+            run_ends = np.r_[breaks, idx_keep.size - 1]
+
+            # Create subsegments for each contiguous run
+            for rs, re in zip(run_starts, run_ends):
+                i0 = idx_keep[rs]
+                i1 = idx_keep[re]
+                sub_start = int(max(seg_start, int(lai_st[i0])))
+                sub_end = int(min(seg_end, int(lai_en[i1])))
+                if sub_end < sub_start:
+                    continue
+
+                # Length filters: bp first
+                if min_bp is not None and (sub_end - sub_start + 1) < int(min_bp):
+                    continue
+
+                # Compute cM length if possible, else approximate or None
+                cm_len = _approx_cm_len(idx_chr, sub_start, sub_end)
+                if cm_len is None and self.__length_cm is not None:
+                    # Scale the original segment length by bp fraction
+                    total_bp = max(1, int(seg_end - seg_start + 1))
+                    frac_bp = float(sub_end - sub_start + 1) / float(total_bp)
+                    try:
+                        cm_len = float(self.__length_cm[i]) * frac_bp
+                    except Exception:
+                        cm_len = None
+
+                # Apply cM filter if requested (treat None as 0)
+                if min_cm is not None:
+                    if cm_len is None or cm_len < float(min_cm):
+                        continue
+
+                # Append trimmed segment
+                out_sample_id_1.append(s1)
+                out_sample_id_2.append(s2)
+                out_haplotype_id_1.append(h1)
+                out_haplotype_id_2.append(h2)
+                out_chrom.append(chrom)
+                out_start.append(sub_start)
+                out_end.append(sub_end)
+                # Always append a cM value aligned with segment count (NaN if unknown)
+                out_length_cm.append(float(cm_len) if cm_len is not None else float('nan'))
+                # Segment type carried over if available
+                if out_segment_type is not None:
+                    out_segment_type.append(str(self.__segment_type[i]))  # type: ignore
+
+        # If nothing remains, return empty object with zero segments
+        if len(out_start) == 0:
+            # Build minimal arrays
+            empty = IBDObject(
+                sample_id_1=np.array([], dtype=object),
+                haplotype_id_1=np.array([], dtype=int),
+                sample_id_2=np.array([], dtype=object),
+                haplotype_id_2=np.array([], dtype=int),
+                chrom=np.array([], dtype=object),
+                start=np.array([], dtype=int),
+                end=np.array([], dtype=int),
+                length_cm=None,
+                segment_type=None if out_segment_type is None else np.array([], dtype=object),
+            )
+            if inplace:
+                self.__sample_id_1 = empty.sample_id_1
+                self.__haplotype_id_1 = empty.haplotype_id_1
+                self.__sample_id_2 = empty.sample_id_2
+                self.__haplotype_id_2 = empty.haplotype_id_2
+                self.__chrom = empty.chrom
+                self.__start = empty.start
+                self.__end = empty.end
+                self.__length_cm = empty.length_cm
+                self.__segment_type = empty.segment_type
+                return None
+            return empty
+
+        # Assemble outputs
+        out_length_array: Optional[np.ndarray]
+        if len(out_length_cm) > 0:
+            # Convert NaNs to None-equivalent by using np.array with dtype float
+            out_length_array = np.asarray(out_length_cm, dtype=float)
+        else:
+            out_length_array = None
+
+        new_obj = IBDObject(
+            sample_id_1=np.asarray(out_sample_id_1, dtype=object),
+            haplotype_id_1=np.asarray(out_haplotype_id_1, dtype=int),
+            sample_id_2=np.asarray(out_sample_id_2, dtype=object),
+            haplotype_id_2=np.asarray(out_haplotype_id_2, dtype=int),
+            chrom=np.asarray(out_chrom, dtype=object),
+            start=np.asarray(out_start, dtype=int),
+            end=np.asarray(out_end, dtype=int),
+            length_cm=out_length_array,
+            segment_type=None if out_segment_type is None else np.asarray(out_segment_type, dtype=object),
+        )
+
+        if inplace:
+            self.__sample_id_1 = new_obj.sample_id_1
+            self.__haplotype_id_1 = new_obj.haplotype_id_1
+            self.__sample_id_2 = new_obj.sample_id_2
+            self.__haplotype_id_2 = new_obj.haplotype_id_2
+            self.__chrom = new_obj.chrom
+            self.__start = new_obj.start
+            self.__end = new_obj.end
+            self.__length_cm = new_obj.length_cm
+            self.__segment_type = new_obj.segment_type
+            return None
+        return new_obj
+
+    def _sanity_check(self) -> None:
+        """
+        Perform sanity checks on the parsed data to ensure data integrity.
+        """
+        n = self.__chrom.shape[0]
+        arrays = [
+            self.__sample_id_1,
+            self.__haplotype_id_1,
+            self.__sample_id_2,
+            self.__haplotype_id_2,
+            self.__start,
+            self.__end,
+        ]
+        if any(arr.shape[0] != n for arr in arrays):
+            raise ValueError("All input arrays must have the same length.")
+
+        if self.__length_cm is not None and self.__length_cm.shape[0] != n:
+            raise ValueError("`length_cm` must have the same length as other arrays.")
+
+        if self.__segment_type is not None and self.__segment_type.shape[0] != n:
+            raise ValueError("`segment_type` must have the same length as other arrays.")
+
+        # Validate haplotype identifiers are 1 or 2, or -1 when unknown
+        valid_values = np.array([1, 2, -1])
+        if not np.isin(self.__haplotype_id_1, valid_values).all() or not np.isin(self.__haplotype_id_2, valid_values).all():
+            raise ValueError("Haplotype identifiers must be in {1, 2} or -1 if unknown.")
+
+

--- a/snputils/ibd/io/__init__.py
+++ b/snputils/ibd/io/__init__.py
@@ -1,0 +1,5 @@
+from .read import read_ibd, HapIBDReader, AncIBDReader, IBDReader
+
+__all__ = ['read_ibd', 'HapIBDReader', 'AncIBDReader', 'IBDReader']
+
+

--- a/snputils/ibd/io/read/__init__.py
+++ b/snputils/ibd/io/read/__init__.py
@@ -1,0 +1,8 @@
+from .functional import read_ibd
+from .hap_ibd import HapIBDReader
+from .anc_ibd import AncIBDReader
+from .auto import IBDReader
+
+__all__ = ['read_ibd', 'HapIBDReader', 'AncIBDReader', 'IBDReader']
+
+

--- a/snputils/ibd/io/read/__test__/test_anc_ibd.py
+++ b/snputils/ibd/io/read/__test__/test_anc_ibd.py
@@ -1,0 +1,102 @@
+import gzip
+import tempfile
+from io import StringIO
+from pathlib import Path
+
+import numpy as np
+
+from snputils.ibd.io.read.anc_ibd import AncIBDReader
+
+
+HEADER = "\t".join([
+    "iid1", "iid2", "ch", "Start", "End", "length", "StartM", "EndM", "lengthM", "StartBP", "EndBP", "segment_type"
+])
+
+ROWS = [
+    ["A", "B", "1", 10, 20, 11, 0.12, 0.22, 0.10, 1000, 2000, "IBD1"],
+    ["C", "D", "2", 30, 40, 11, 0.30, 0.45, 0.15, 3000, 4000, "IBD2"],
+]
+
+
+def _tsv_lines(rows):
+    lines = [HEADER]
+    for r in rows:
+        lines.append("\t".join(map(str, r)))
+    return lines
+
+
+def _write_text(path: Path, lines):
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _write_gz(path: Path, lines):
+    with gzip.open(path, "wt") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def test_ancibd_read_file_plain():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        file = tmp_path / "ch_all.tsv"
+        _write_text(file, _tsv_lines(ROWS))
+
+        reader = AncIBDReader(file)
+        ibd = reader.read()
+
+        assert ibd.n_segments == 2
+        assert ibd.sample_id_1.tolist() == ["A", "C"]
+        assert ibd.sample_id_2.tolist() == ["B", "D"]
+        assert ibd.chrom.tolist() == ["1", "2"]
+        assert ibd.start.tolist() == [1000, 3000]
+        assert ibd.end.tolist() == [2000, 4000]
+        # length_cm is lengthM * 100
+        np.testing.assert_allclose(ibd.length_cm.tolist(), [10.0, 15.0])
+        # ancIBD does not provide haplotype IDs
+        assert set(ibd.haplotype_id_1.tolist()) == {-1}
+        assert set(ibd.haplotype_id_2.tolist()) == {-1}
+
+
+def test_ancibd_read_file_gz():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        file = tmp_path / "ch_all.tsv.gz"
+        _write_gz(file, _tsv_lines(ROWS))
+
+        reader = AncIBDReader(file)
+        ibd = reader.read()
+
+        assert ibd.n_segments == 2
+        assert ibd.start.tolist() == [1000, 3000]
+        assert ibd.end.tolist() == [2000, 4000]
+
+
+def test_ancibd_read_directory_with_ch_files():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        ch1 = tmp_path / "ch1.tsv"
+        ch2 = tmp_path / "ch2.tsv.gz"
+        _write_text(ch1, _tsv_lines([ROWS[0]]))
+        _write_gz(ch2, _tsv_lines([ROWS[1]]))
+
+        reader = AncIBDReader(tmp_path)
+        ibd = reader.read()
+
+        assert ibd.n_segments == 2
+        assert ibd.chrom.tolist() == ["1", "2"]
+
+
+def test_ancibd_filter_segment_type():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        file = tmp_path / "ch_all.tsv"
+        _write_text(file, _tsv_lines(ROWS))
+
+        reader = AncIBDReader(file)
+        ibd = reader.read(include_segment_types=["IBD1"])  # filter to IBD1 only
+
+        assert ibd.n_segments == 1
+        assert ibd.sample_id_1.tolist() == ["A"]
+        assert ibd.sample_id_2.tolist() == ["B"]
+        assert ibd.chrom.tolist() == ["1"]
+
+

--- a/snputils/ibd/io/read/__test__/test_hap_ibd.py
+++ b/snputils/ibd/io/read/__test__/test_hap_ibd.py
@@ -1,0 +1,122 @@
+import gzip
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+from snputils.ibd.io.read.hap_ibd import HapIBDReader
+
+
+def _write_text(path: Path, lines):
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _write_gz(path: Path, lines):
+    with gzip.open(path, "wt") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def _build_lines(tokens, joiner: str) -> list:
+    return [joiner.join(map(str, row)) for row in tokens]
+
+
+TOKENS = [
+    ["SUBJ-A", 1, "SUBJ-B", 2, "chr10", 46535262, 48183075, 2.320],
+    ["SUBJ-C", 2, "SUBJ-D", 1, "chr2", 100, 200, 1.23],
+    ["SUBJ-E", 1, "SUBJ-E", 2, "chrX", 123, 456, 0.01],
+]
+
+
+def test_hap_ibd_whitespace_default_separator_plain():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        # Mix spaces and tabs, with variable spacing
+        whitespace_lines = [
+            "SUBJ-A    1    SUBJ-B\t2   chr10   46535262   48183075   2.320",
+            "SUBJ-C  2  SUBJ-D  1  chr2   100  200  1.23",
+            "SUBJ-E\t1   SUBJ-E  2  chrX   123   456  0.01",
+        ]
+        file = tmp_path / "example.ibd"
+        _write_text(file, whitespace_lines)
+
+        reader = HapIBDReader(file)
+        ibd = reader.read()
+
+        assert ibd.n_segments == 3
+        assert ibd.sample_id_1.tolist() == [r[0] for r in TOKENS]
+        assert ibd.haplotype_id_1.tolist() == [r[1] for r in TOKENS]
+        assert ibd.sample_id_2.tolist() == [r[2] for r in TOKENS]
+        assert ibd.haplotype_id_2.tolist() == [r[3] for r in TOKENS]
+        assert ibd.chrom.tolist() == [r[4] for r in TOKENS]
+        assert ibd.start.tolist() == [r[5] for r in TOKENS]
+        assert ibd.end.tolist() == [r[6] for r in TOKENS]
+        np.testing.assert_allclose(ibd.length_cm.tolist(), [r[7] for r in TOKENS], rtol=0, atol=0)
+
+
+def test_hap_ibd_tab_explicit_separator_plain():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        tab_lines = _build_lines(TOKENS, "\t")
+        file = tmp_path / "example_tabs.ibd"
+        _write_text(file, tab_lines)
+
+        reader = HapIBDReader(file)
+        ibd = reader.read(separator="\t")
+
+        assert ibd.n_segments == 3
+        assert ibd.sample_id_1.tolist() == [r[0] for r in TOKENS]
+        assert ibd.haplotype_id_1.tolist() == [r[1] for r in TOKENS]
+        assert ibd.sample_id_2.tolist() == [r[2] for r in TOKENS]
+        assert ibd.haplotype_id_2.tolist() == [r[3] for r in TOKENS]
+        assert ibd.chrom.tolist() == [r[4] for r in TOKENS]
+        assert ibd.start.tolist() == [r[5] for r in TOKENS]
+        assert ibd.end.tolist() == [r[6] for r in TOKENS]
+        np.testing.assert_allclose(ibd.length_cm.tolist(), [r[7] for r in TOKENS], rtol=0, atol=0)
+
+
+def test_hap_ibd_whitespace_default_separator_gz():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        whitespace_lines = [
+            "SUBJ-A    1    SUBJ-B\t2   chr10   46535262   48183075   2.320",
+            "SUBJ-C  2  SUBJ-D  1  chr2   100  200  1.23",
+            "SUBJ-E\t1   SUBJ-E  2  chrX   123   456  0.01",
+        ]
+        file = tmp_path / "example.ibd.gz"
+        _write_gz(file, whitespace_lines)
+
+        reader = HapIBDReader(file)
+        ibd = reader.read()
+
+        assert ibd.n_segments == 3
+        assert ibd.sample_id_1.tolist() == [r[0] for r in TOKENS]
+        assert ibd.haplotype_id_1.tolist() == [r[1] for r in TOKENS]
+        assert ibd.sample_id_2.tolist() == [r[2] for r in TOKENS]
+        assert ibd.haplotype_id_2.tolist() == [r[3] for r in TOKENS]
+        assert ibd.chrom.tolist() == [r[4] for r in TOKENS]
+        assert ibd.start.tolist() == [r[5] for r in TOKENS]
+        assert ibd.end.tolist() == [r[6] for r in TOKENS]
+        np.testing.assert_allclose(ibd.length_cm.tolist(), [r[7] for r in TOKENS], rtol=0, atol=0)
+
+
+def test_hap_ibd_tab_explicit_separator_gz():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        tab_lines = _build_lines(TOKENS, "\t")
+        file = tmp_path / "example_tabs.ibd.gz"
+        _write_gz(file, tab_lines)
+
+        reader = HapIBDReader(file)
+        ibd = reader.read(separator="\t")
+
+        assert ibd.n_segments == 3
+        assert ibd.sample_id_1.tolist() == [r[0] for r in TOKENS]
+        assert ibd.haplotype_id_1.tolist() == [r[1] for r in TOKENS]
+        assert ibd.sample_id_2.tolist() == [r[2] for r in TOKENS]
+        assert ibd.haplotype_id_2.tolist() == [r[3] for r in TOKENS]
+        assert ibd.chrom.tolist() == [r[4] for r in TOKENS]
+        assert ibd.start.tolist() == [r[5] for r in TOKENS]
+        assert ibd.end.tolist() == [r[6] for r in TOKENS]
+        np.testing.assert_allclose(ibd.length_cm.tolist(), [r[7] for r in TOKENS], rtol=0, atol=0)
+
+

--- a/snputils/ibd/io/read/anc_ibd.py
+++ b/snputils/ibd/io/read/anc_ibd.py
@@ -1,4 +1,3 @@
-import gzip
 import logging
 from io import StringIO
 from pathlib import Path
@@ -82,13 +81,7 @@ class AncIBDReader(IBDBaseReader):
         }
 
         for f in files:
-            is_gz = str(f).endswith(".gz")
-            if is_gz:
-                with gzip.open(f, "rt") as fh:
-                    text = fh.read()
-                frame = pl.read_csv(StringIO(text), separator="\t", has_header=True, schema_overrides=schema_overrides)
-            else:
-                frame = pl.read_csv(str(f), separator="\t", has_header=True, schema_overrides=schema_overrides)
+            frame = pl.read_csv(str(f), separator="\t", has_header=True, schema_overrides=schema_overrides)
             frames.append(frame)
 
         df = pl.concat(frames, how="vertical") if len(frames) > 1 else frames[0]

--- a/snputils/ibd/io/read/anc_ibd.py
+++ b/snputils/ibd/io/read/anc_ibd.py
@@ -1,0 +1,126 @@
+import gzip
+import logging
+from io import StringIO
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+import polars as pl
+import numpy as np
+
+from snputils.ibd.genobj.ibdobj import IBDObject
+from snputils.ibd.io.read.base import IBDBaseReader
+
+
+log = logging.getLogger(__name__)
+
+
+class AncIBDReader(IBDBaseReader):
+    """
+    Reads IBD data from ancIBD outputs (TSV), accepting a file (`ch_all.tsv` or `ch*.tsv`) or a directory.
+    """
+
+    def read(
+        self,
+        path: Optional[Union[str, Path]] = None,
+        include_segment_types: Optional[Sequence[str]] = ("IBD1", "IBD2"),
+    ) -> IBDObject:
+        """
+        Read ancIBD outputs and convert to `IBDObject`.
+
+        Inputs accepted:
+        - A single TSV (optionally gzipped), e.g. `ch_all.tsv[.gz]` or `ch{CHR}.tsv[.gz]`.
+        - A directory containing per-chromosome TSVs or `ch_all.tsv`.
+
+        Column schema (tab-separated with header):
+        iid1, iid2, ch, Start, End, length, StartM, EndM, lengthM, StartBP, EndBP, segment_type
+
+        Notes:
+        - Haplotype indices are not provided by ancIBD; set to -1.
+        - Positions in IBDObject use base-pair StartBP/EndBP.
+        - Length uses centiMorgan as `lengthM * 100`.
+
+        Args:
+            path (str or Path, optional): Override input path. Defaults to `self.file`.
+            include_segment_types (sequence of str, optional): Filter by `segment_type` (e.g., IBD1, IBD2). None to disable.
+
+        Returns:
+            **IBDObject**: An IBDObject instance.
+        """
+        p = Path(path) if path is not None else Path(self.file)
+        log.info(f"Reading ancIBD from {p}")
+
+        files: list[Path]
+        if p.is_dir():
+            # Prefer combined file if present, else gather per-chromosome files
+            combined = p / "ch_all.tsv"
+            combined_gz = p / "ch_all.tsv.gz"
+            if combined.exists():
+                files = [combined]
+            elif combined_gz.exists():
+                files = [combined_gz]
+            else:
+                files = sorted(list(p.glob("ch*.tsv")) + list(p.glob("ch*.tsv.gz")))
+                if not files:
+                    raise FileNotFoundError("No ancIBD output files found in directory.")
+        else:
+            files = [p]
+
+        frames = []
+        schema_overrides = {
+            "iid1": pl.Utf8,
+            "iid2": pl.Utf8,
+            "ch": pl.Utf8,
+            "Start": pl.Int64,
+            "End": pl.Int64,
+            "length": pl.Int64,  # marker span; not used
+            "StartM": pl.Float64,
+            "EndM": pl.Float64,
+            "lengthM": pl.Float64,
+            "StartBP": pl.Int64,
+            "EndBP": pl.Int64,
+            "segment_type": pl.Utf8,
+        }
+
+        for f in files:
+            is_gz = str(f).endswith(".gz")
+            if is_gz:
+                with gzip.open(f, "rt") as fh:
+                    text = fh.read()
+                frame = pl.read_csv(StringIO(text), separator="\t", has_header=True, schema_overrides=schema_overrides)
+            else:
+                frame = pl.read_csv(str(f), separator="\t", has_header=True, schema_overrides=schema_overrides)
+            frames.append(frame)
+
+        df = pl.concat(frames, how="vertical") if len(frames) > 1 else frames[0]
+
+        if include_segment_types is not None:
+            df = df.filter(pl.col("segment_type").is_in(list(include_segment_types)))
+
+        # Map columns to IBDObject schema
+        sample_id_1 = df["iid1"].to_numpy()
+        sample_id_2 = df["iid2"].to_numpy()
+        chrom = df["ch"].to_numpy()
+        start_bp = df["StartBP"].to_numpy()
+        end_bp = df["EndBP"].to_numpy()
+        length_cm = (df["lengthM"] * 100.0).to_numpy()
+
+        # ancIBD doesn't include haplotype indices; set to -1
+        hap1 = np.full(sample_id_1.shape[0], -1, dtype=np.int8)
+        hap2 = np.full(sample_id_2.shape[0], -1, dtype=np.int8)
+
+        ibdobj = IBDObject(
+            sample_id_1=sample_id_1,
+            haplotype_id_1=hap1,
+            sample_id_2=sample_id_2,
+            haplotype_id_2=hap2,
+            chrom=chrom,
+            start=start_bp,
+            end=end_bp,
+            length_cm=length_cm,
+            segment_type=df["segment_type"].to_numpy(),
+        )
+
+        log.info(f"Finished reading ancIBD from {p}")
+        return ibdobj
+
+

--- a/snputils/ibd/io/read/auto.py
+++ b/snputils/ibd/io/read/auto.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+
+class IBDReader:
+    def __new__(
+        cls,
+        file: Union[str, Path]
+    ) -> object:
+        """
+        A factory class that attempts to detect the IBD file format and returns the corresponding reader.
+
+        Supported detections:
+        - Hap-IBD: *.ibd or *.ibd.gz (headerless, 8 columns)
+        - ancIBD: directories with `ch_all.tsv`/`ch*.tsv` or files *.tsv / *.tsv.gz with ancIBD schema
+        """
+        file = Path(file)
+        suffixes = [s.lower() for s in file.suffixes]
+
+        # Directory-based detection for ancIBD
+        if file.is_dir():
+            if (file / 'ch_all.tsv').exists() or (file / 'ch_all.tsv.gz').exists():
+                from snputils.ibd.io.read.anc_ibd import AncIBDReader
+                return AncIBDReader(file)
+            has_chr_files = list(file.glob('ch*.tsv')) or list(file.glob('ch*.tsv.gz'))
+            if has_chr_files:
+                from snputils.ibd.io.read.anc_ibd import AncIBDReader
+                return AncIBDReader(file)
+            # Fallback to HapIBD if nothing matches
+            from snputils.ibd.io.read.hap_ibd import HapIBDReader
+            return HapIBDReader(file)
+
+        # File-based detection
+        if suffixes[-2:] == ['.ibd', '.gz'] or suffixes[-1:] == ['.ibd']:
+            from snputils.ibd.io.read.hap_ibd import HapIBDReader
+            return HapIBDReader(file)
+        if suffixes[-2:] == ['.tsv', '.gz'] or suffixes[-1:] == ['.tsv']:
+            from snputils.ibd.io.read.anc_ibd import AncIBDReader
+            return AncIBDReader(file)
+
+        # Default to HapIBDReader (most tools use .ibd[.gz])
+        from snputils.ibd.io.read.hap_ibd import HapIBDReader
+        return HapIBDReader(file)
+
+

--- a/snputils/ibd/io/read/base.py
+++ b/snputils/ibd/io/read/base.py
@@ -1,0 +1,37 @@
+import abc
+from pathlib import Path
+from typing import Union
+
+from snputils.ibd.genobj.ibdobj import IBDObject
+
+
+class IBDBaseReader(abc.ABC):
+    """
+    Abstract class for IBD readers.
+    """
+
+    def __init__(self, file: Union[str, Path]) -> None:
+        """
+        Args:
+            file (str or pathlib.Path): Path to the IBD file to read.
+        """
+        self.__file = Path(file)
+
+    @property
+    def file(self) -> Path:
+        """
+        Retrieve `file`.
+
+        Returns:
+            pathlib.Path: Path to the IBD file to read.
+        """
+        return self.__file
+
+    @abc.abstractmethod
+    def read(self) -> IBDObject:
+        """
+        Abstract method to read data from the provided `file` and construct an `IBDObject`.
+        """
+        pass
+
+

--- a/snputils/ibd/io/read/functional.py
+++ b/snputils/ibd/io/read/functional.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from typing import Union
+
+from snputils.ibd.genobj.ibdobj import IBDObject
+
+
+def read_ibd(file: Union[str, Path], **kwargs) -> IBDObject:
+    """
+    Automatically detect the IBD data file format from the file's extension and read it into an `IBDObject`.
+
+    Supported formats:
+    - Hap-IBD (no standard extension; defaults to tab-delimited columns without header).
+    - ancIBD (template only).
+
+    Args:
+        file (str or pathlib.Path): Path to the file to be read.
+        **kwargs: Additional arguments passed to the reader method.
+    """
+    from snputils.ibd.io.read.auto import IBDReader
+
+    return IBDReader(file).read(**kwargs)
+
+

--- a/snputils/ibd/io/read/hap_ibd.py
+++ b/snputils/ibd/io/read/hap_ibd.py
@@ -74,43 +74,22 @@ class HapIBDReader(IBDBaseReader):
                 },
             )
         else:
-            if is_gz:
-                # Read decompressed content into memory and let polars parse it
-                with gzip.open(self.file, 'rt') as f:
-                    text = f.read()
-                df = pl.read_csv(
-                    source=StringIO(text),
-                    has_header=False,
-                    separator=separator,
-                    new_columns=col_names,
-                    schema_overrides={
-                        'sample_id_1': pl.Utf8,
-                        'haplotype_id_1': pl.Int8,
-                        'sample_id_2': pl.Utf8,
-                        'haplotype_id_2': pl.Int8,
-                        'chrom': pl.Utf8,
-                        'start': pl.Int64,
-                        'end': pl.Int64,
-                        'length_cm': pl.Float64,
-                    },
-                )
-            else:
-                df = pl.read_csv(
-                    source=str(self.file),
-                    has_header=False,
-                    separator=separator,
-                    new_columns=col_names,
-                    schema_overrides={
-                        'sample_id_1': pl.Utf8,
-                        'haplotype_id_1': pl.Int8,
-                        'sample_id_2': pl.Utf8,
-                        'haplotype_id_2': pl.Int8,
-                        'chrom': pl.Utf8,
-                        'start': pl.Int64,
-                        'end': pl.Int64,
-                        'length_cm': pl.Float64,
-                    },
-                )
+            df = pl.read_csv(
+                source=str(self.file),
+                has_header=False,
+                separator=separator,
+                new_columns=col_names,
+                schema_overrides={
+                    'sample_id_1': pl.Utf8,
+                    'haplotype_id_1': pl.Int8,
+                    'sample_id_2': pl.Utf8,
+                    'haplotype_id_2': pl.Int8,
+                    'chrom': pl.Utf8,
+                    'start': pl.Int64,
+                    'end': pl.Int64,
+                    'length_cm': pl.Float64,
+                },
+            )
 
         ibdobj = IBDObject(
             sample_id_1=df['sample_id_1'].to_numpy(),

--- a/snputils/ibd/io/read/hap_ibd.py
+++ b/snputils/ibd/io/read/hap_ibd.py
@@ -1,0 +1,129 @@
+import logging
+from typing import Optional
+
+import numpy as np
+import polars as pl
+import gzip
+import re
+from io import StringIO
+
+from snputils.ibd.genobj.ibdobj import IBDObject
+from snputils.ibd.io.read.base import IBDBaseReader
+
+
+log = logging.getLogger(__name__)
+
+
+class HapIBDReader(IBDBaseReader):
+    """
+    Reads an IBD file in Hap-IBD format and processes it into an `IBDObject`.
+    """
+
+    def read(self, separator: Optional[str] = None) -> IBDObject:
+        """
+        Read a Hap-IBD file into an `IBDObject`.
+
+        The Hap-IBD format is a delimited text without a header with columns:
+        sample_id_1, haplotype_id_1, sample_id_2, haplotype_id_2, chromosome, start, end, length_cm
+
+        Notes:
+        - Haplotype identifiers are 1-based and take values in {1, 2}.
+
+        Args:
+            separator (str, optional): Field delimiter. If None, whitespace (any number of spaces or tabs) is assumed.
+
+        Returns:
+            **IBDObject**: An IBDObject instance.
+        """
+        log.info(f"Reading {self.file}")
+
+        # Column names for Hap-IBD files (no header present in input)
+        col_names = [
+            'sample_id_1', 'haplotype_id_1', 'sample_id_2', 'haplotype_id_2',
+            'chrom', 'start', 'end', 'length_cm'
+        ]
+
+        # Detect gzip by extension
+        is_gz = str(self.file).endswith('.gz')
+
+        # If separator is None, treat as whitespace-delimited (any spaces or tabs)
+        if separator is None:
+            # Polars doesn't support regex separators; normalize whitespace to single tabs before parsing
+            if is_gz:
+                with gzip.open(self.file, 'rt') as f:
+                    lines = [re.sub(r"\s+", "\t", line.strip()) for line in f if line.strip()]
+            else:
+                with open(self.file, 'r') as f:
+                    lines = [re.sub(r"\s+", "\t", line.strip()) for line in f if line.strip()]
+
+            data = StringIO("\n".join(lines))
+            df = pl.read_csv(
+                source=data,
+                has_header=False,
+                separator='\t',
+                new_columns=col_names,
+                schema_overrides={
+                    'sample_id_1': pl.Utf8,
+                    'haplotype_id_1': pl.Int8,
+                    'sample_id_2': pl.Utf8,
+                    'haplotype_id_2': pl.Int8,
+                    'chrom': pl.Utf8,
+                    'start': pl.Int64,
+                    'end': pl.Int64,
+                    'length_cm': pl.Float64,
+                },
+            )
+        else:
+            if is_gz:
+                # Read decompressed content into memory and let polars parse it
+                with gzip.open(self.file, 'rt') as f:
+                    text = f.read()
+                df = pl.read_csv(
+                    source=StringIO(text),
+                    has_header=False,
+                    separator=separator,
+                    new_columns=col_names,
+                    schema_overrides={
+                        'sample_id_1': pl.Utf8,
+                        'haplotype_id_1': pl.Int8,
+                        'sample_id_2': pl.Utf8,
+                        'haplotype_id_2': pl.Int8,
+                        'chrom': pl.Utf8,
+                        'start': pl.Int64,
+                        'end': pl.Int64,
+                        'length_cm': pl.Float64,
+                    },
+                )
+            else:
+                df = pl.read_csv(
+                    source=str(self.file),
+                    has_header=False,
+                    separator=separator,
+                    new_columns=col_names,
+                    schema_overrides={
+                        'sample_id_1': pl.Utf8,
+                        'haplotype_id_1': pl.Int8,
+                        'sample_id_2': pl.Utf8,
+                        'haplotype_id_2': pl.Int8,
+                        'chrom': pl.Utf8,
+                        'start': pl.Int64,
+                        'end': pl.Int64,
+                        'length_cm': pl.Float64,
+                    },
+                )
+
+        ibdobj = IBDObject(
+            sample_id_1=df['sample_id_1'].to_numpy(),
+            haplotype_id_1=df['haplotype_id_1'].to_numpy(),
+            sample_id_2=df['sample_id_2'].to_numpy(),
+            haplotype_id_2=df['haplotype_id_2'].to_numpy(),
+            chrom=df['chrom'].to_numpy(),
+            start=df['start'].to_numpy(),
+            end=df['end'].to_numpy(),
+            length_cm=df['length_cm'].to_numpy(),
+            segment_type=np.array(["IBD1"] * df.height),  # hap-IBD does not distinguish; treat as IBD1
+        )
+
+        log.info(f"Finished reading {self.file}")
+
+        return ibdobj


### PR DESCRIPTION
This branch introduces a new `IBDObject` class for handling identity-by-descent (IBD) segments, with:

- Readers for hap-IBD and ancIBD file formats
- `restrict_to_ancestry()` method to filter IBD segments by local ancestry with strict/lenient modes
- Comprehensive test coverage