### PR TITLE
Speed-up BEDReader and PGENReader by using chunked contiguous allele-reads

### DIFF
--- a/snputils/snp/io/read/__test__/test_pgenlib.py
+++ b/snputils/snp/io/read/__test__/test_pgenlib.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+from snputils.snp.io.read import _pgenlib
+
+
+class _FakePgenReader:
+    def __init__(self, alleles: np.ndarray):
+        self._alleles = alleles
+        self.range_calls = []
+        self.list_calls = []
+
+    def read_alleles_range(self, start: int, stop: int, out: np.ndarray) -> None:
+        self.range_calls.append((start, stop))
+        out[:] = self._alleles[start:stop]
+
+    def read_alleles_list(self, variant_idxs: np.ndarray, out: np.ndarray) -> None:
+        idxs = np.asarray(variant_idxs, dtype=np.uint32)
+        self.list_calls.append(idxs.copy())
+        out[:] = self._alleles[idxs]
+
+
+def test_chunked_separate_strands_contiguous_range_and_list_fallback_match(monkeypatch):
+    num_samples = 3
+    allele_cols = 2 * num_samples
+    all_alleles = np.arange(12 * allele_cols, dtype=np.int32).reshape(12, allele_cols)
+    variant_idxs = np.arange(2, 10, dtype=np.uint32)
+    num_variants = variant_idxs.size
+
+    monkeypatch.setattr(_pgenlib, "PHASED_ALLELE_FULL_READ_BYTES", 1)
+
+    reader_with_range = _FakePgenReader(all_alleles)
+    gt_from_range = _pgenlib.read_separate_strands(
+        reader_with_range, variant_idxs, num_variants, num_samples
+    )
+
+    monkeypatch.setattr(_pgenlib, "_is_contiguous_variant_chunk", lambda _: False)
+    reader_with_list = _FakePgenReader(all_alleles)
+    gt_from_list = _pgenlib.read_separate_strands(
+        reader_with_list, variant_idxs, num_variants, num_samples
+    )
+
+    assert reader_with_range.range_calls == [(2, 10)]
+    assert reader_with_range.list_calls == []
+    assert reader_with_list.range_calls == []
+    assert len(reader_with_list.list_calls) == 1
+    np.testing.assert_array_equal(reader_with_list.list_calls[0], variant_idxs)
+
+    assert gt_from_range.shape == (num_variants, num_samples, 2)
+    assert gt_from_range.dtype == np.int8
+    np.testing.assert_array_equal(gt_from_range, gt_from_list)

--- a/snputils/snp/io/read/_pgenlib.py
+++ b/snputils/snp/io/read/_pgenlib.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+
+PHASED_ALLELE_FULL_READ_BYTES = 64 * 1024 * 1024
+PHASED_ALLELE_CHUNK_BYTES = 16 * 1024 * 1024
+PHASED_ALLELE_MAX_CHUNK_VARIANTS = 512
+
+
+def _allele_int32_bytes(num_variants: int, num_samples: int) -> int:
+    return int(num_variants) * 2 * int(num_samples) * np.dtype(np.int32).itemsize
+
+
+def _phased_chunk_size(num_variants: int, num_samples: int) -> int:
+    bytes_per_variant = 2 * int(num_samples) * np.dtype(np.int32).itemsize
+    if bytes_per_variant == 0:
+        return int(num_variants)
+    return max(
+        1,
+        min(
+            int(num_variants),
+            PHASED_ALLELE_MAX_CHUNK_VARIANTS,
+            PHASED_ALLELE_CHUNK_BYTES // bytes_per_variant,
+        ),
+    )
+
+
+def estimate_separate_strands_peak_bytes(num_variants: int, num_samples: int) -> int:
+    output_bytes = int(num_variants) * int(num_samples) * 2 * np.dtype(np.int8).itemsize
+    int32_bytes = _allele_int32_bytes(num_variants, num_samples)
+    if int32_bytes <= PHASED_ALLELE_FULL_READ_BYTES:
+        return output_bytes + int32_bytes
+    chunk_bytes = _allele_int32_bytes(_phased_chunk_size(num_variants, num_samples), num_samples)
+    return output_bytes + chunk_bytes
+
+
+def _is_contiguous_variant_chunk(variant_idxs: np.ndarray) -> bool:
+    return (
+        variant_idxs.size > 0
+        and int(variant_idxs[-1]) - int(variant_idxs[0]) + 1 == variant_idxs.size
+        and np.all(np.diff(variant_idxs) == 1)
+    )
+
+
+def read_separate_strands(
+    pgen_reader,
+    variant_idxs: np.ndarray,
+    num_variants: int,
+    num_samples: int,
+) -> np.ndarray:
+    """Read diploid alleles into a compact `(variants, samples, 2)` int8 array."""
+    if num_variants == 0 or num_samples == 0:
+        return np.empty((num_variants, num_samples, 2), dtype=np.int8)
+
+    variant_idxs = np.asarray(variant_idxs, dtype=np.uint32).ravel()
+    allele_cols = 2 * int(num_samples)
+
+    if _allele_int32_bytes(num_variants, num_samples) <= PHASED_ALLELE_FULL_READ_BYTES:
+        genotypes = np.empty((num_variants, allele_cols), dtype=np.int32)
+        pgen_reader.read_alleles_list(variant_idxs, genotypes)
+        return genotypes.astype(np.int8).reshape((num_variants, num_samples, 2))
+
+    genotypes = np.empty((num_variants, num_samples, 2), dtype=np.int8)
+    chunk_size = _phased_chunk_size(num_variants, num_samples)
+    allele_chunk = np.empty((chunk_size, allele_cols), dtype=np.int32)
+
+    for start in range(0, num_variants, chunk_size):
+        stop = min(start + chunk_size, num_variants)
+        chunk_len = stop - start
+        chunk_variant_idxs = variant_idxs[start:stop]
+        chunk = allele_chunk[:chunk_len]
+
+        if _is_contiguous_variant_chunk(chunk_variant_idxs):
+            pgen_reader.read_alleles_range(
+                int(chunk_variant_idxs[0]),
+                int(chunk_variant_idxs[-1]) + 1,
+                chunk,
+            )
+        else:
+            pgen_reader.read_alleles_list(chunk_variant_idxs, chunk)
+
+        np.copyto(
+            genotypes[start:stop].reshape(chunk_len, allele_cols),
+            chunk,
+            casting="unsafe",
+        )
+
+    return genotypes

--- a/snputils/snp/io/read/bed.py
+++ b/snputils/snp/io/read/bed.py
@@ -8,6 +8,10 @@ import pgenlib as pg
 
 from snputils.snp.genobj.snpobj import SNPObject
 from snputils.snp.io.read.base import SNPBaseReader
+from snputils.snp.io.read._pgenlib import (
+    estimate_separate_strands_peak_bytes,
+    read_separate_strands,
+)
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +45,7 @@ class BEDReader(SNPBaseReader):
             variant_idxs: List of variant indices to read. If None and variant_ids is None, all variants are read.
             sum_strands: If True, maternal and paternal strands are combined into a single `int8` array with values `{0, 1, 2`}. 
                 If False, strands are stored separately as an `int8` array with values `{0, 1}` for each strand. 
-                Note: With the pgenlib backend, `False` uses `~8×` more RAM, though `calldata_gt` is only `2×` larger.
+                Note: With the pgenlib backend, `False` uses a temporary `int32` allele buffer.
             separator: Separator used in the pvar file. If None, the separator is automatically detected.
                 If the automatic detection fails, please specify the separator manually.
 
@@ -168,15 +172,21 @@ class BEDReader(SNPBaseReader):
 
             # required arrays: variant_idxs + sample_idxs + genotypes
             if not sum_strands:
-                required_ram = (num_samples + num_variants + num_variants * 2 * num_samples) * 4
+                required_ram = (
+                    (num_samples + num_variants) * 4
+                    + estimate_separate_strands_peak_bytes(num_variants, num_samples)
+                )
             else:
                 required_ram = (num_samples + num_variants) * 4 + num_variants * num_samples
             log.info(f">{required_ram / 1024**3:.2f} GiB of RAM are required to process {num_samples} samples with {num_variants} variants each")
 
             if not sum_strands:
-                genotypes = np.empty((num_variants, 2 * num_samples), dtype=np.int32)  # cannot use int8 because of pgenlib
-                pgen_reader.read_alleles_list(variant_idxs, genotypes)
-                genotypes = genotypes.astype(np.int8).reshape((num_variants, num_samples, 2))
+                genotypes = read_separate_strands(
+                    pgen_reader,
+                    variant_idxs,
+                    num_variants,
+                    num_samples,
+                )
             else:
                 genotypes = np.empty((num_variants, num_samples), dtype=np.int8)
                 pgen_reader.read_list(variant_idxs, genotypes)

--- a/snputils/snp/io/read/pgen.py
+++ b/snputils/snp/io/read/pgen.py
@@ -9,6 +9,10 @@ import pgenlib as pg
 
 from snputils.snp.genobj.snpobj import SNPObject
 from snputils.snp.io.read.base import SNPBaseReader
+from snputils.snp.io.read._pgenlib import (
+    estimate_separate_strands_peak_bytes,
+    read_separate_strands,
+)
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +53,7 @@ class PGENReader(SNPBaseReader):
             variant_idxs: List of variant indices to read. If None and variant_ids is None, all variants are read.
             sum_strands: If True, maternal and paternal strands are combined into a single `int8` array with values `{0, 1, 2`}. 
                 If False, strands are stored separately as an `int8` array with values `{0, 1}` for each strand. 
-                Note: With the pgenlib backend, `False` uses `~8×` more RAM, though `calldata_gt` is only `2×` larger.
+                Note: With the pgenlib backend, `False` uses a temporary `int32` allele buffer.
             separator: Separator used in the pvar file. If None, the separator is automatically detected.
                 If the automatic detection fails, please specify the separator manually.
 
@@ -222,15 +226,21 @@ class PGENReader(SNPBaseReader):
 
             # required arrays: variant_idxs + sample_idxs + genotypes
             if not sum_strands:
-                required_ram = (num_samples + num_variants + num_variants * 2 * num_samples) * 4
+                required_ram = (
+                    (num_samples + num_variants) * 4
+                    + estimate_separate_strands_peak_bytes(num_variants, num_samples)
+                )
             else:
                 required_ram = (num_samples + num_variants) * 4 + num_variants * num_samples
             log.info(f">{required_ram / 1024**3:.2f} GiB of RAM are required to process {num_samples} samples with {num_variants} variants each")
 
             if not sum_strands:
-                genotypes = np.empty((num_variants, 2 * num_samples), dtype=np.int32)  # cannot use int8 because of pgenlib
-                pgen_reader.read_alleles_list(variant_idxs, genotypes)
-                genotypes = genotypes.astype(np.int8).reshape((num_variants, num_samples, 2))
+                genotypes = read_separate_strands(
+                    pgen_reader,
+                    variant_idxs,
+                    num_variants,
+                    num_samples,
+                )
             else:
                 genotypes = np.empty((num_variants, num_samples), dtype=np.int8)
                 pgen_reader.read_list(variant_idxs, genotypes)

--- a/snputils/snp/io/read/pgen.py
+++ b/snputils/snp/io/read/pgen.py
@@ -51,8 +51,8 @@ class PGENReader(SNPBaseReader):
             sample_idxs: List of sample indices to read. If None and sample_ids is None, all samples are read.
             variant_ids: List of variant IDs to read. If None and variant_idxs is None, all variants are read.
             variant_idxs: List of variant indices to read. If None and variant_ids is None, all variants are read.
-            sum_strands: If True, maternal and paternal strands are combined into a single `int8` array with values `{0, 1, 2`}. 
-                If False, strands are stored separately as an `int8` array with values `{0, 1}` for each strand. 
+            sum_strands: If True, maternal and paternal strands are combined into a single `int8` array with values `{0, 1, 2}`.
+                If False, strands are stored separately as an `int8` array with values `{0, 1}` for each strand.
                 Note: With the pgenlib backend, `False` uses a temporary `int32` allele buffer.
             separator: Separator used in the pvar file. If None, the separator is automatically detected.
                 If the automatic detection fails, please specify the separator manually.


### PR DESCRIPTION
  Full chr22 timing after the change:
  - new PGENReader: 2.337s mean
  - previous default:      ~4.13s mean

Full chr22 BED timing:
- new BEDReader:      1.560s mean
- old full-int32 path: 3.561s mean

Now we should be faster than pgenlib itself