### PR TITLE
Move pygrgl to an optional dependency group and temporally install from repo fork with fixed build system on macOS

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,6 +24,7 @@ Install feature-specific dependencies with pip extras:
 | Extra | Command | Purpose |
 |-------|---------|---------|
 | `torch` | `pip install "snputils[torch]"` | GPU-accelerated PCA (`TorchPCA`) and the `simulate` CLI |
+| `grg` | `pip install "snputils[grg]"` | GRG readers, writers, and helpers |
 | `docs` | `pip install "snputils[docs]"` | Build this documentation locally |
 | `demos` | `pip install "snputils[demos]"` | Run or edit tutorial notebooks |
 | `tests` | `pip install "snputils[tests]"` | pytest and coverage tooling |
@@ -33,7 +34,7 @@ Extras can be combined: `pip install "snputils[torch,docs]"`.
 ## Format-specific notes
 
 - **PLINK2 PGEN** — uses [Pgenlib](https://pypi.org/project/Pgenlib/), included as a core dependency.
-- **GRG** — reading and writing genotype representation graphs requires [pygrgl](https://pypi.org/project/pygrgl/), also included in core dependencies.
+- **GRG** — reading and writing genotype representation graphs requires [pygrgl](https://pypi.org/project/pygrgl/), installed by the `grg` extra.
 - **PyTorch workflows** — install the `torch` extra before using `TorchPCA`, `OnlineSimulator`, or `snputils simulate`.
 
 ## Build documentation locally

--- a/docs/user_guide/data-model.md
+++ b/docs/user_guide/data-model.md
@@ -149,7 +149,7 @@ covar.n_covariates
 
 ## GRGObject
 
-Genotype Representation Graph (requires `pip install pygrgl`).
+Genotype Representation Graph (requires `pip install "snputils[grg]"`).
 
 ```python
 grg = su.read_grg("cohort.grg")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,5 +95,6 @@ passenv =
 extras =
     tests
     torch
+    grg
 commands = python -m pytest -vv --color=yes --cov=snputils --cov-report=xml
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ docs = [
 benchmark = ["pytest", "pytest-benchmark", "memory_profiler",
              "pandas-plink", "pysam", "scikit-allel", "sgkit[plink]", "hail>=0.2.130", "pysnptools", "Pgenlib", "cyvcf2", "plinkio", "PyVCF3"]
 grg = [
-    "pygrgl @ git+https://github.com/salcc/grgl.git@cb908272f188ac26163b17dba545def69bc9ae0c"
+    "pygrgl @ git+https://github.com/salcc/grgl.git@f31e7f6eeddd114ed56d4c963ff908dcebb1de0a"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "nbformat",
     "adjustText",
     "zstandard",
-    "pygrgl",
     "cairosvg"
 ]
 
@@ -57,6 +56,9 @@ docs = [
 ]
 benchmark = ["pytest", "pytest-benchmark", "memory_profiler",
              "pandas-plink", "pysam", "scikit-allel", "sgkit[plink]", "hail>=0.2.130", "pysnptools", "Pgenlib", "cyvcf2", "plinkio", "PyVCF3"]
+grg = [
+    "pygrgl @ git+https://github.com/salcc/grgl.git@cb908272f188ac26163b17dba545def69bc9ae0c"
+]
 
 [project.urls]
 "Homepage" = "https://snputils.org"

--- a/snputils/datasets/synthetic.py
+++ b/snputils/datasets/synthetic.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
 import pandas as pd
-import pygrgl as pyg
 
 from snputils.ancestry.genobj.local import LocalAncestryObject
 from snputils.phenotype.genobj import (
@@ -12,9 +11,11 @@ from snputils.phenotype.genobj import (
     MultiPhenotypeObject,
     PhenotypeObject,
 )
-from snputils.snp.genobj.grgobj import GRGObject
 from snputils.snp.genobj.snpobj import SNPObject
 from snputils.visualization.constants import CHROM_SIZES
+
+if TYPE_CHECKING:
+    from snputils.snp.genobj.grgobj import GRGObject
 
 
 DEFAULT_SYNTHETIC_ANCESTRY_MAP = {"0": "AFR", "1": "EUR", "2": "EAS"}
@@ -819,6 +820,17 @@ def build_synthetic_chromosome_painting_dataset(
 
 def build_synthetic_grg() -> GRGObject:
     """Build a tiny deterministic GRGObject."""
+    try:
+        import pygrgl as pyg
+        from snputils.snp.genobj.grgobj import GRGObject
+    except ModuleNotFoundError as exc:
+        if exc.name == "pygrgl":
+            raise ImportError(
+                "GRG support requires the optional dependency 'pygrgl'. "
+                "Install it with: pip install 'snputils[grg]'"
+            ) from exc
+        raise
+
     grg = pyg.MutableGRG(6, 2, True)
     root = grg.make_node()
     left = grg.make_node()

--- a/snputils/snp/genobj/__init__.py
+++ b/snputils/snp/genobj/__init__.py
@@ -11,7 +11,7 @@ def __getattr__(name):
             if exc.name == "pygrgl":
                 raise ImportError(
                     "GRG support requires the optional dependency 'pygrgl'. "
-                    "Install it with: pip install pygrgl"
+                    "Install it with: pip install 'snputils[grg]'"
                 ) from exc
             raise
         return GRGObject

--- a/snputils/snp/io/read/__init__.py
+++ b/snputils/snp/io/read/__init__.py
@@ -29,7 +29,7 @@ def __getattr__(name):
             if exc.name == "pygrgl":
                 raise ImportError(
                     "GRG support requires the optional dependency 'pygrgl'. "
-                    "Install it with: pip install pygrgl"
+                    "Install it with: pip install 'snputils[grg]'"
                 ) from exc
             raise
         return GRGReader

--- a/snputils/snp/io/read/functional.py
+++ b/snputils/snp/io/read/functional.py
@@ -97,7 +97,7 @@ def read_grg(filename: Union[str, pathlib.Path], **kwargs) -> "GRGObject":
         if exc.name == "pygrgl":
             raise ImportError(
                 "GRG support requires the optional dependency 'pygrgl'. "
-                "Install it with: pip install pygrgl"
+                "Install it with: pip install 'snputils[grg]'"
             ) from exc
         raise
 

--- a/snputils/snp/io/write/__init__.py
+++ b/snputils/snp/io/write/__init__.py
@@ -15,7 +15,7 @@ def __getattr__(name):
             if exc.name == "pygrgl":
                 raise ImportError(
                     "GRG support requires the optional dependency 'pygrgl'. "
-                    "Install it with: pip install pygrgl"
+                    "Install it with: pip install 'snputils[grg]'"
                 ) from exc
             raise
         return GRGWriter


### PR DESCRIPTION
Currently pygrgl requires cmake to install on macOS, but the project does not define it as a build dependency, which caused  a crash when doing pip install snputils. Temporally, we install pygrgl from https://github.com/salcc/grgl/commit/f31e7f6eeddd114ed56d4c963ff908dcebb1de0a which fixes the issue. I also submitted PR https://github.com/aprilweilab/grgl/pull/145; once it gets accepted and released we should go back to the regular PyPI dependency.