### PR TITLE
Fix package build

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -133,18 +133,26 @@ jobs:
           python-version: '3.14'  # Ensure this is the latest Python version so the cached deps are used
           cache: 'pip'
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential zlib1g-dev
-
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install build
 
-      - name: Build package
-        run: python -m build
+      - name: Build sdist
+        run: |
+          rm -rf dist wheelhouse
+          python -m build --sdist
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v4.1.0
+        with:
+          output-dir: wheelhouse
+        env:
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+          CIBW_SKIP: "*-musllinux_*"
+
+      - name: Move wheels into dist
+        run: cp wheelhouse/*.whl dist/
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Removed installation of system dependencies as they are supposedly already included in the pypa/manylinux image, and updated build steps to include separate sdist and wheels builds so that PyPI publishing does not fail.